### PR TITLE
Indentation fixes and month numbers

### DIFF
--- a/bibmanager/ads_manager/ads_manager.py
+++ b/bibmanager/ads_manager/ads_manager.py
@@ -25,374 +25,374 @@ from .. import utils as u
 
 
 def manager(querry=None):
-  """
-  A manager, it doesn't really do anything, it just delegates.
-  """
-  rows  = int(cm.get('ads_display'))
-  if querry is None and not os.path.exists(u.BM_CACHE):
-      print("There are no more entries for this querry.")
-      return
+    """
+    A manager, it doesn't really do anything, it just delegates.
+    """
+    rows  = int(cm.get('ads_display'))
+    if querry is None and not os.path.exists(u.BM_CACHE):
+        print("There are no more entries for this querry.")
+        return
 
-  if querry is None:
-      with open(u.BM_CACHE, 'rb') as handle:
-          results, querry, start, index, nmatch = pickle.load(handle)
-      last = start + len(results)
-      if last < nmatch and index + rows > last:
-          new_results, nmatch = search(querry, start=last)
-          results = results[index-start:] + new_results
-          start = index
-          last = start + len(results)
-  else:
-      start = 0
-      index = start
-      results, nmatch = search(querry, start=start)
+    if querry is None:
+        with open(u.BM_CACHE, 'rb') as handle:
+            results, querry, start, index, nmatch = pickle.load(handle)
+        last = start + len(results)
+        if last < nmatch and index + rows > last:
+            new_results, nmatch = search(querry, start=last)
+            results = results[index-start:] + new_results
+            start = index
+            last = start + len(results)
+    else:
+        start = 0
+        index = start
+        results, nmatch = search(querry, start=start)
 
-  display(results, start, index, rows, nmatch)
-  index += rows
-  if index >= nmatch:
-      with u.ignored(OSError):
-          os.remove(u.BM_CACHE)
-  else:
-      with open(u.BM_CACHE, 'wb') as handle:
-          pickle.dump([results, querry, start, index, nmatch], handle,
-                      protocol=pickle.HIGHEST_PROTOCOL)
+    display(results, start, index, rows, nmatch)
+    index += rows
+    if index >= nmatch:
+        with u.ignored(OSError):
+            os.remove(u.BM_CACHE)
+    else:
+        with open(u.BM_CACHE, 'wb') as handle:
+            pickle.dump([results, querry, start, index, nmatch], handle,
+                        protocol=pickle.HIGHEST_PROTOCOL)
 
 
 def search(querry, start=0, cache_rows=200, sort='pubdate+desc'):
-  """
-  Make a querry from ADS.
+    """
+    Make a querry from ADS.
 
-  Parameters
-  ----------
-  querry: String
-     A querry string like an entry in the new ADS interface:
-     https://ui.adsabs.harvard.edu/
-  start: Integer
-     Starting index of entry to return.
-  cache_rows: Integer
-     Maximum number of entries to return.
-  sort: String
-     Sorting field and direction to use.
+    Parameters
+    ----------
+    querry: String
+       A querry string like an entry in the new ADS interface:
+       https://ui.adsabs.harvard.edu/
+    start: Integer
+       Starting index of entry to return.
+    cache_rows: Integer
+       Maximum number of entries to return.
+    sort: String
+       Sorting field and direction to use.
 
-  Returns
-  -------
-  results: List of dicts
-     Querry outputs between indices start and start+rows.
-  nmatch: Integer
-     Total number of entries matched by the querry.
+    Returns
+    -------
+    results: List of dicts
+       Querry outputs between indices start and start+rows.
+    nmatch: Integer
+       Total number of entries matched by the querry.
 
-  Resources
-  ---------
-  A comprehensive description of the querry format:
-  - http://adsabs.github.io/help/search/
-  Description of the querry parameters:
-  - https://github.com/adsabs/adsabs-dev-api/blob/master/Search_API.ipynb
+    Resources
+    ---------
+    A comprehensive description of the querry format:
+    - http://adsabs.github.io/help/search/
+    Description of the querry parameters:
+    - https://github.com/adsabs/adsabs-dev-api/blob/master/Search_API.ipynb
 
-  Examples
-  --------
-  >>> import bibmanager.ads_manager as am
-  >>> # Search entries by author (note the need for double quotes,
-  >>> # otherwise, the search might produce bogus results):
-  >>> querry = 'author:"cubillos, p"'
-  >>> results, nmatch = am.search(querry)
-  >>> # Search entries by first author:
-  >>> querry = 'author:"^cubillos, p"'
-  >>> # Combine search by first author and year:
-  >>> querry = 'author:"^cubillos, p" year:2017'
-  >>> # Restrict seach to article-type entries:
-  >>> querry = 'author:"^cubillos, p" property:article'
-  >>> # Restrict seach to peer-reviewed articles:
-  >>> querry = 'author:"^cubillos, p" property:refereed'
+    Examples
+    --------
+    >>> import bibmanager.ads_manager as am
+    >>> # Search entries by author (note the need for double quotes,
+    >>> # otherwise, the search might produce bogus results):
+    >>> querry = 'author:"cubillos, p"'
+    >>> results, nmatch = am.search(querry)
+    >>> # Search entries by first author:
+    >>> querry = 'author:"^cubillos, p"'
+    >>> # Combine search by first author and year:
+    >>> querry = 'author:"^cubillos, p" year:2017'
+    >>> # Restrict seach to article-type entries:
+    >>> querry = 'author:"^cubillos, p" property:article'
+    >>> # Restrict seach to peer-reviewed articles:
+    >>> querry = 'author:"^cubillos, p" property:refereed'
 
-  >>> # Attempt with invalid token:
-  >>> results, nmatch = am.search(querry)
-  ValueError: Invalid ADS request: Unauthorized, check you have a valid ADS token.
-  >>> # Attempt with invalid querry ('properties' instead of 'property'):
-  >>> results, nmatch = am.search('author:"^cubillos, p" properties:refereed')
-  ValueError: Invalid ADS request:
-  org.apache.solr.search.SyntaxError: org.apache.solr.common.SolrException: undefined field properties
-  """
-  token = cm.get('ads_token')
-  querry = urllib.parse.quote(querry)
+    >>> # Attempt with invalid token:
+    >>> results, nmatch = am.search(querry)
+    ValueError: Invalid ADS request: Unauthorized, check you have a valid ADS token.
+    >>> # Attempt with invalid querry ('properties' instead of 'property'):
+    >>> results, nmatch = am.search('author:"^cubillos, p" properties:refereed')
+    ValueError: Invalid ADS request:
+    org.apache.solr.search.SyntaxError: org.apache.solr.common.SolrException: undefined field properties
+    """
+    token = cm.get('ads_token')
+    querry = urllib.parse.quote(querry)
 
-  r = requests.get('https://api.adsabs.harvard.edu/v1/search/query?'
-                  f'q={querry}&start={start}&rows={cache_rows}'
-                   f'&sort={sort}&fl=title,author,year,bibcode,pub',
-                   headers={'Authorization': f'Bearer {token}'})
-  resp = r.json()
-  if 'error' in resp:
-      if resp['error'] == 'Unauthorized':
-          raise ValueError(f"Invalid ADS request: {resp['error']}, "
-                            "check you have a valid ADS token.")
-      raise ValueError(f"Invalid ADS request:\n{resp['error']['msg']}.")
+    r = requests.get('https://api.adsabs.harvard.edu/v1/search/query?'
+                    f'q={querry}&start={start}&rows={cache_rows}'
+                     f'&sort={sort}&fl=title,author,year,bibcode,pub',
+                     headers={'Authorization': f'Bearer {token}'})
+    resp = r.json()
+    if 'error' in resp:
+        if resp['error'] == 'Unauthorized':
+            raise ValueError(f"Invalid ADS request: {resp['error']}, "
+                              "check you have a valid ADS token.")
+        raise ValueError(f"Invalid ADS request:\n{resp['error']['msg']}.")
 
-  nmatch  = resp['response']['numFound']
-  results = resp['response']['docs']
+    nmatch  = resp['response']['numFound']
+    results = resp['response']['docs']
 
-  return results, nmatch
+    return results, nmatch
 
 
 def display(results, start, index, rows, nmatch, short=True):
-  """
-  Show on the prompt a list of entries from an ADS search.
+    """
+    Show on the prompt a list of entries from an ADS search.
 
-  Parameters
-  ----------
-  results: List of dicts
-     Subset of entries returned by a querry.
-  start: Integer
-     Index assigned to first entry in results.
-  index: Integer
-     First index to display.
-  rows: Integer
-     Number of entries to display.
-  nmatch: Integer
-     Total number of entries corresponding to querry (not necessarily
-     the number of entries in results).
-  short: Bool
-     Format for author list. If True, truncate with 'et al' after
-     the second author.
+    Parameters
+    ----------
+    results: List of dicts
+       Subset of entries returned by a querry.
+    start: Integer
+       Index assigned to first entry in results.
+    index: Integer
+       First index to display.
+    rows: Integer
+       Number of entries to display.
+    nmatch: Integer
+       Total number of entries corresponding to querry (not necessarily
+       the number of entries in results).
+    short: Bool
+       Format for author list. If True, truncate with 'et al' after
+       the second author.
 
-  Examples
-  --------
-  >>> import bibmanager.ads_manager as am
-  >>> start = index = 0
-  >>> querry = 'author:"^cubillos, p" property:refereed'
-  >>> results, nmatch = am.search(querry, start=start)
-  >>> display(results, start, index, rows, nmatch)
-  """
-  for result in results[index-start:index-start+rows]:
-      title = textwrap.fill(f"Title: {result['title'][0]}", width=78,
-                            subsequent_indent='       ')
-      author_list = [u.parse_name(author) for author in result['author']]
-      authors = textwrap.fill(f"Authors: {u.get_authors(author_list, short)}",
-                              width=78, subsequent_indent='    ')
-      adsurl = ("adsurl:  https://ui.adsabs.harvard.edu/abs/" +
-               f"{result['bibcode']}")
-      bibcode = f"\n{u.BOLD}bibcode{u.END}: {result['bibcode']}"
-      print(f"\n{title}\n{authors}\n{adsurl}{bibcode}")
-  if index + rows < nmatch:
-      more = "  To show the next set, execute:\nbibm ads-search -n"
-  else:
-      more = ""
-  print(f"\nShowing entries {index+1}--{min(index+rows, nmatch)} out of "
-        f"{nmatch} matches.{more}")
+    Examples
+    --------
+    >>> import bibmanager.ads_manager as am
+    >>> start = index = 0
+    >>> querry = 'author:"^cubillos, p" property:refereed'
+    >>> results, nmatch = am.search(querry, start=start)
+    >>> display(results, start, index, rows, nmatch)
+    """
+    for result in results[index-start:index-start+rows]:
+        title = textwrap.fill(f"Title: {result['title'][0]}", width=78,
+                              subsequent_indent='       ')
+        author_list = [u.parse_name(author) for author in result['author']]
+        authors = textwrap.fill(f"Authors: {u.get_authors(author_list, short)}",
+                                width=78, subsequent_indent='    ')
+        adsurl = ("adsurl:  https://ui.adsabs.harvard.edu/abs/" +
+                 f"{result['bibcode']}")
+        bibcode = f"\n{u.BOLD}bibcode{u.END}: {result['bibcode']}"
+        print(f"\n{title}\n{authors}\n{adsurl}{bibcode}")
+    if index + rows < nmatch:
+        more = "  To show the next set, execute:\nbibm ads-search -n"
+    else:
+        more = ""
+    print(f"\nShowing entries {index+1}--{min(index+rows, nmatch)} out of "
+          f"{nmatch} matches.{more}")
 
 
 def add_bibtex(input_bibcodes, input_keys, eprints=[], dois=[],
                update_keys=True, base=None):
-  """
-  Add bibtex entries from a list of ADS bibcodes, with specified keys.
-  New entries will replace old ones without asking if they are
-  duplicates.
+    """
+    Add bibtex entries from a list of ADS bibcodes, with specified keys.
+    New entries will replace old ones without asking if they are
+    duplicates.
 
-  Parameters
-  ----------
-  input_bibcodes: List of strings
-      A list of ADS bibcodes.
-  imput_keys: List of strings
-      BibTeX keys to assign to each bibcode.
-  eprints: List of strings
-      List of ArXiv IDs corresponding to the input bibcodes.
-  dois: List of strings
-      List of DOIs corresponding to the input bibcodes.
-  update_keys: Bool
-      If True, attempt to update keys of entries that were updated
-      from arxiv to published versions.
-  base: List of Bib() objects
-      If None, merge new entries into the bibmanager database.
-      If not None, merge new entries into base.
+    Parameters
+    ----------
+    input_bibcodes: List of strings
+        A list of ADS bibcodes.
+    imput_keys: List of strings
+        BibTeX keys to assign to each bibcode.
+    eprints: List of strings
+        List of ArXiv IDs corresponding to the input bibcodes.
+    dois: List of strings
+        List of DOIs corresponding to the input bibcodes.
+    update_keys: Bool
+        If True, attempt to update keys of entries that were updated
+        from arxiv to published versions.
+    base: List of Bib() objects
+        If None, merge new entries into the bibmanager database.
+        If not None, merge new entries into base.
 
-  Returns
-  -------
-  bibs: List of Bib() objects
-      Updated list of BibTeX entries.
+    Returns
+    -------
+    bibs: List of Bib() objects
+        Updated list of BibTeX entries.
 
-  Examples
-  --------
-  >>> import bibmanager.ads_manager as am
-  >>> # A successful add call:
-  >>> bibcodes = ['1925PhDT.........1P']
-  >>> keys = ['Payne1925phdStellarAtmospheres']
-  >>> am.add_bibtex(bibcodes, keys)
-  >>> # A failing add call:
-  >>> bibcodes = ['1925PhDT....X....1P']
-  >>> am.add_bibtex(bibcodes, keys)
-  Error: There were no entries found for the input bibcodes.
+    Examples
+    --------
+    >>> import bibmanager.ads_manager as am
+    >>> # A successful add call:
+    >>> bibcodes = ['1925PhDT.........1P']
+    >>> keys = ['Payne1925phdStellarAtmospheres']
+    >>> am.add_bibtex(bibcodes, keys)
+    >>> # A failing add call:
+    >>> bibcodes = ['1925PhDT....X....1P']
+    >>> am.add_bibtex(bibcodes, keys)
+    Error: There were no entries found for the input bibcodes.
 
-  >>> # A successful add call with multiple entries:
-  >>> bibcodes = ['1925PhDT.........1P', '2018MNRAS.481.5286F']
-  >>> keys = ['Payne1925phdStellarAtmospheres', 'FolsomEtal2018mnrasHD219134']
-  >>> am.add_bibtex(bibcodes, keys)
-  >>> # A partially failing call will still add those that succeed:
-  >>> bibcodes = ['1925PhDT.....X...1P', '2018MNRAS.481.5286F']
-  >>> am.add_bibtex(bibcodes, keys)
-  Warning: bibcode '1925PhDT.....X...1P' not found.
-  """
-  token = cm.get('ads_token')
-  # Keep the originals untouched (copies will be modified):
-  bibcodes, keys = input_bibcodes.copy(), input_keys.copy()
+    >>> # A successful add call with multiple entries:
+    >>> bibcodes = ['1925PhDT.........1P', '2018MNRAS.481.5286F']
+    >>> keys = ['Payne1925phdStellarAtmospheres', 'FolsomEtal2018mnrasHD219134']
+    >>> am.add_bibtex(bibcodes, keys)
+    >>> # A partially failing call will still add those that succeed:
+    >>> bibcodes = ['1925PhDT.....X...1P', '2018MNRAS.481.5286F']
+    >>> am.add_bibtex(bibcodes, keys)
+    Warning: bibcode '1925PhDT.....X...1P' not found.
+    """
+    token = cm.get('ads_token')
+    # Keep the originals untouched (copies will be modified):
+    bibcodes, keys = input_bibcodes.copy(), input_keys.copy()
 
-  # Make request:
-  r = requests.post("https://api.adsabs.harvard.edu/v1/export/bibtex",
-                    headers={"Authorization": f'Bearer {token}',
-                             "Content-type": "application/json"},
-                    data=json.dumps({"bibcode":bibcodes}))
-  resp = r.json()
+    # Make request:
+    r = requests.post("https://api.adsabs.harvard.edu/v1/export/bibtex",
+                      headers={"Authorization": f'Bearer {token}',
+                               "Content-type": "application/json"},
+                      data=json.dumps({"bibcode":bibcodes}))
+    resp = r.json()
 
-  # No valid outputs:
-  if 'error' in resp:
-      if resp['error'] == 'Unauthorized':
-          print('\nError: Unauthorized access to ADS.  Check that the ADS '
-                'token is valid.')
-      elif resp['error'] == 'no result from solr':
-          print("\nError: There were no entries found for the input bibcodes.")
-      else:
-          print("\nError: ADS request returned an error message:"
-               f"\n{resp['error']}")
-      return
+    # No valid outputs:
+    if 'error' in resp:
+        if resp['error'] == 'Unauthorized':
+            print('\nError: Unauthorized access to ADS.  Check that the ADS '
+                  'token is valid.')
+        elif resp['error'] == 'no result from solr':
+            print("\nError: There were no entries found for the input bibcodes.")
+        else:
+            print("\nError: ADS request returned an error message:"
+                 f"\n{resp['error']}")
+        return
 
-  # Keep counts of things:
-  nfound = int(resp['msg'].split()[1])
-  nreqs  = len(bibcodes)
+    # Keep counts of things:
+    nfound = int(resp['msg'].split()[1])
+    nreqs  = len(bibcodes)
 
-  # Split output into separate BibTeX entries (keep as strings):
-  results = resp["export"].strip().split("\n\n")
+    # Split output into separate BibTeX entries (keep as strings):
+    results = resp["export"].strip().split("\n\n")
 
-  new_keys = []
-  new_bibs = []
-  founds = [False for _ in bibcodes]
-  arxiv_updates = 0
-  # Match results to bibcodes,keys:
-  for result in reversed(results):
-      ibib = None
-      new = bm.Bib(result)
-      rkey   = new.key
-      doi    = new.doi
-      eprint = new.eprint
-      # Output bibcode is input bibcode:
-      if rkey in bibcodes:
-          ibib = bibcodes.index(rkey)
-          new_key = keys[ibib]
-      # Else, check for bibcode updates in remaining bibcodes:
-      elif eprint is not None and eprint in eprints:
-          ibib = eprints.index(eprint)
-      elif doi is not None and doi in dois:
-          ibib = dois.index(doi)
+    new_keys = []
+    new_bibs = []
+    founds = [False for _ in bibcodes]
+    arxiv_updates = 0
+    # Match results to bibcodes,keys:
+    for result in reversed(results):
+        ibib = None
+        new = bm.Bib(result)
+        rkey   = new.key
+        doi    = new.doi
+        eprint = new.eprint
+        # Output bibcode is input bibcode:
+        if rkey in bibcodes:
+            ibib = bibcodes.index(rkey)
+            new_key = keys[ibib]
+        # Else, check for bibcode updates in remaining bibcodes:
+        elif eprint is not None and eprint in eprints:
+            ibib = eprints.index(eprint)
+        elif doi is not None and doi in dois:
+            ibib = dois.index(doi)
 
-      if ibib is not None:
-          new_key = keys[ibib]
-          updated_key = key_update(new_key, rkey, bibcodes[ibib])
-          if update_keys and updated_key.lower() != new_key.lower():
-              new_key = updated_key
-              new_keys.append([keys[ibib], new_key])
-          if 'arXiv' in bibcodes[ibib] and 'arXiv' not in new.bibcode:
-              arxiv_updates += 1
+        if ibib is not None:
+            new_key = keys[ibib]
+            updated_key = key_update(new_key, rkey, bibcodes[ibib])
+            if update_keys and updated_key.lower() != new_key.lower():
+                new_key = updated_key
+                new_keys.append([keys[ibib], new_key])
+            if 'arXiv' in bibcodes[ibib] and 'arXiv' not in new.bibcode:
+                arxiv_updates += 1
 
-          new.update_key(new_key)
-          new_bibs.append(new)
-          founds[ibib] = True
-          results.remove(result)
+            new.update_key(new_key)
+            new_bibs.append(new)
+            founds[ibib] = True
+            results.remove(result)
 
-  # Warnings:
-  if nfound < nreqs or len(results) > 0:
-      warning = u.BANNER + "Warning:\n"
-      # bibcodes not found
-      missing = [bibcode for bibcode,found in zip(bibcodes, founds)
-                 if not found]
-      if nfound < nreqs:
-          warning += '\nThere were bibcodes unmatched or not found in ADS:\n - '
-          warning += '\n - '.join(missing) + "\n"
-      # bibcodes not matched:
-      if len(results) > 0:
-          warning += '\nThese ADS results did not match input bibcodes:\n\n'
-          warning += '\n\n'.join(results) + "\n"
-      warning += u.BANNER
-      print(warning)
+    # Warnings:
+    if nfound < nreqs or len(results) > 0:
+        warning = u.BANNER + "Warning:\n"
+        # bibcodes not found
+        missing = [bibcode for bibcode,found in zip(bibcodes, founds)
+                   if not found]
+        if nfound < nreqs:
+            warning += '\nThere were bibcodes unmatched or not found in ADS:\n - '
+            warning += '\n - '.join(missing) + "\n"
+        # bibcodes not matched:
+        if len(results) > 0:
+            warning += '\nThese ADS results did not match input bibcodes:\n\n'
+            warning += '\n\n'.join(results) + "\n"
+        warning += u.BANNER
+        print(warning)
 
-  # Add to bibmanager database or base:
-  updated = bm.merge(new=new_bibs, take='new', base=base)
-  print('(Not counting updated references)')
+    # Add to bibmanager database or base:
+    updated = bm.merge(new=new_bibs, take='new', base=base)
+    print('(Not counting updated references)')
 
-  # Report arXiv updates:
-  if arxiv_updates > 0:
-      print(f"\nThere were {arxiv_updates} entries updated from ArXiv to "
-             "their peer-reviewed version.")
-  if len(new_keys) > 0:
-      new_keys = [f"  {old} -> {new}" for old,new in new_keys
-                  if old != new]
-      if len(new_keys) > 0:
-          print("These entries changed their key:\n" + "\n".join(new_keys))
-  return updated
+    # Report arXiv updates:
+    if arxiv_updates > 0:
+        print(f"\nThere were {arxiv_updates} entries updated from ArXiv to "
+               "their peer-reviewed version.")
+    if len(new_keys) > 0:
+        new_keys = [f"  {old} -> {new}" for old,new in new_keys
+                    if old != new]
+        if len(new_keys) > 0:
+            print("These entries changed their key:\n" + "\n".join(new_keys))
+    return updated
 
 
 def update(update_keys=True, base=None):
-  """
-  Do an ADS querry by bibcode for all entries that have an ADS bibcode.
-  Replacing old entries with the new ones.  The main use of
-  this function is to update arxiv version of articles.
+    """
+    Do an ADS querry by bibcode for all entries that have an ADS bibcode.
+    Replacing old entries with the new ones.  The main use of
+    this function is to update arxiv version of articles.
 
-  Parameters
-  ----------
-  update_keys: Bool
-      If True, attempt to update keys of entries that were updated
-      from arxiv to published versions.
-  """
-  if base is None:
-      bibs = bm.load()
-  else:
-      bibs = base
+    Parameters
+    ----------
+    update_keys: Bool
+        If True, attempt to update keys of entries that were updated
+        from arxiv to published versions.
+    """
+    if base is None:
+        bibs = bm.load()
+    else:
+        bibs = base
 
-  keys     = [bib.key     for bib in bibs if bib.bibcode is not None]
-  bibcodes = [bib.bibcode for bib in bibs if bib.bibcode is not None]
-  eprints  = [bib.eprint  for bib in bibs if bib.bibcode is not None]
-  dois     = [bib.doi     for bib in bibs if bib.bibcode is not None]
-  # Querry-replace:
-  bibs = add_bibtex(bibcodes, keys, eprints, dois, update_keys, base=base)
-  return bibs
+    keys     = [bib.key     for bib in bibs if bib.bibcode is not None]
+    bibcodes = [bib.bibcode for bib in bibs if bib.bibcode is not None]
+    eprints  = [bib.eprint  for bib in bibs if bib.bibcode is not None]
+    dois     = [bib.doi     for bib in bibs if bib.bibcode is not None]
+    # Querry-replace:
+    bibs = add_bibtex(bibcodes, keys, eprints, dois, update_keys, base=base)
+    return bibs
 
 
 def key_update(key, bibcode, alternate_bibcode):
-  r"""
-  Update key with year and journal of arxiv version of a key.
+    r"""
+    Update key with year and journal of arxiv version of a key.
 
-  This function will search and update the year in a key,
-  and the journal if the key contains the word 'arxiv' (case
-  insensitive).
+    This function will search and update the year in a key,
+    and the journal if the key contains the word 'arxiv' (case
+    insensitive).
 
-  The function extracts the info from the old and new bibcodes.
-  ADS bibcode format: http://adsabs.github.io/help/actions/bibcode
+    The function extracts the info from the old and new bibcodes.
+    ADS bibcode format: http://adsabs.github.io/help/actions/bibcode
 
-  Examples
-  --------
-  >>> import bibmanager.ads_manager as am
-  >>> key = 'BeaulieuEtal2010arxivGJ436b'
-  >>> bibcode           = '2011ApJ...731...16B'
-  >>> alternate_bibcode = '2010arXiv1007.0324B'
-  >>> new_key = am.key_update(key, bibcode, alternate_bibcode)
-  >>> print(f'{key}\n{new_key}')
-  BeaulieuEtal2010arxivGJ436b
-  BeaulieuEtal2011apjGJ436b
+    Examples
+    --------
+    >>> import bibmanager.ads_manager as am
+    >>> key = 'BeaulieuEtal2010arxivGJ436b'
+    >>> bibcode           = '2011ApJ...731...16B'
+    >>> alternate_bibcode = '2010arXiv1007.0324B'
+    >>> new_key = am.key_update(key, bibcode, alternate_bibcode)
+    >>> print(f'{key}\n{new_key}')
+    BeaulieuEtal2010arxivGJ436b
+    BeaulieuEtal2011apjGJ436b
 
-  >>> key = 'CubillosEtal2018arXivRetrievals'
-  >>> bibcode           = '2019A&A...550A.100B'
-  >>> alternate_bibcode = '2018arXiv123401234B'
-  >>> new_key = am.key_update(key, bibcode, alternate_bibcode)
-  >>> print(f'{key}\n{new_key}')
-  CubillosEtal2018arXivRetrievals
-  CubillosEtal2019aaRetrievals
-  """
-  old_year = alternate_bibcode[0:4]
-  year = bibcode[0:4]
-  # Update year:
-  if old_year != year and old_year in key:
-      key = key.replace(old_year, year, 1)
+    >>> key = 'CubillosEtal2018arXivRetrievals'
+    >>> bibcode           = '2019A&A...550A.100B'
+    >>> alternate_bibcode = '2018arXiv123401234B'
+    >>> new_key = am.key_update(key, bibcode, alternate_bibcode)
+    >>> print(f'{key}\n{new_key}')
+    CubillosEtal2018arXivRetrievals
+    CubillosEtal2019aaRetrievals
+    """
+    old_year = alternate_bibcode[0:4]
+    year = bibcode[0:4]
+    # Update year:
+    if old_year != year and old_year in key:
+        key = key.replace(old_year, year, 1)
 
-  # Update journal:
-  journal = bibcode[4:9].replace('.','').replace('&','').lower()
-  # Search for the word 'arxiv' in key:
-  ijournal = key.lower().find('arxiv')
-  if ijournal >= 0:
-      key = "".join([key[:ijournal], journal, key[ijournal+5:]])
+    # Update journal:
+    journal = bibcode[4:9].replace('.','').replace('&','').lower()
+    # Search for the word 'arxiv' in key:
+    ijournal = key.lower().find('arxiv')
+    if ijournal >= 0:
+        key = "".join([key[:ijournal], journal, key[ijournal+5:]])
 
-  return key
+    return key

--- a/bibmanager/bib_manager/bib_manager.py
+++ b/bibmanager/bib_manager/bib_manager.py
@@ -112,7 +112,11 @@ class Bib(object):
             elif key == "month":
                 value = value.lower().strip()
                 if value.isdigit():
-                    self.month = int(value)
+                    month = int(value)
+                    if month in months.values():
+                        self.month = month
+                    else:
+                        raise ValueError(month)
                 else:
                     self.month = months[value[0:3]]
 

--- a/bibmanager/bib_manager/bib_manager.py
+++ b/bibmanager/bib_manager/bib_manager.py
@@ -41,838 +41,841 @@ from .. import utils as u
 # Some constant definitions:
 lexer = prompt_toolkit.lexers.PygmentsLexer(BibTeXLexer)
 
-months  = {"jan":1, "feb":2, "mar":3, "apr": 4, "may": 5, "jun":6,
-           "jul":7, "aug":8, "sep":9, "oct":10, "nov":11, "dec":12}
+months  = {"jan": 1, "feb": 2, "mar": 3, "apr": 4, "may": 5, "jun": 6,
+           "jul": 7, "aug": 8, "sep": 9, "oct": 10, "nov": 11, "dec": 12}
 
 
 class Bib(object):
-  """
-  Bibliographic-entry object.
-  """
-  def __init__(self, entry):
-      """
-      Create a Bib() object from given entry.  Minimally, entries must
-      contain the author, title, and year keys.
+    """
+    Bibliographic-entry object.
+    """
+    def __init__(self, entry):
+        """
+        Create a Bib() object from given entry.  Minimally, entries must
+        contain the author, title, and year keys.
 
-      Parameters
-      ----------
-      entry: String
-         A bibliographic entry text.
+        Parameters
+        ----------
+        entry: String
+           A bibliographic entry text.
 
-      Examples
-      --------
-      >>> import bibmanager.bib_manager as bm
-      >>> from bibmanager.utils import Author
-      >>> entry = '''@Misc{JonesEtal2001scipy,
-                author = {Eric Jones and Travis Oliphant and Pearu Peterson},
-                title  = {{SciPy}: Open source scientific tools for {Python}},
-                year   = {2001},
-              }'''
-      >>> bib = bm.Bib(entry)
-      >>> print(bib.title)
-      SciPy: Open source scientific tools for Python
-      >>> for author in bib.authors:
-      >>>    print(author)
-      Author(last='Jones', first='Eric', von='', jr='')
-      Author(last='Oliphant', first='Travis', von='', jr='')
-      Author(last='Peterson', first='Pearu', von='', jr='')
-      >>> print(bib.sort_author)
-      Sort_author(last='jones', first='e', von='', jr='', year=2001, month=13)
-      """
-      if u.count(entry) != 0:
-          raise ValueError("Mismatched braces in entry.")
-      self.content  = entry
-      # Defaults:
-      self.month    = 13
-      self.adsurl   = None
-      self.bibcode  = None
-      self.doi      = None
-      self.eprint   = None
-      self.isbn     = None
+        Examples
+        --------
+        >>> import bibmanager.bib_manager as bm
+        >>> from bibmanager.utils import Author
+        >>> entry = '''@Misc{JonesEtal2001scipy,
+                  author = {Eric Jones and Travis Oliphant and Pearu Peterson},
+                  title  = {{SciPy}: Open source scientific tools for {Python}},
+                  year   = {2001},
+                }'''
+        >>> bib = bm.Bib(entry)
+        >>> print(bib.title)
+        SciPy: Open source scientific tools for Python
+        >>> for author in bib.authors:
+        >>>    print(author)
+        Author(last='Jones', first='Eric', von='', jr='')
+        Author(last='Oliphant', first='Travis', von='', jr='')
+        Author(last='Peterson', first='Pearu', von='', jr='')
+        >>> print(bib.sort_author)
+        Sort_author(last='jones', first='e', von='', jr='', year=2001, month=13)
+        """
+        if u.count(entry) != 0:
+            raise ValueError("Mismatched braces in entry.")
+        self.content  = entry
+        # Defaults:
+        self.month    = 13
+        self.adsurl   = None
+        self.bibcode  = None
+        self.doi      = None
+        self.eprint   = None
+        self.isbn     = None
 
-      fields = u.get_fields(self.content)
-      self.key = next(fields)
+        fields = u.get_fields(self.content)
+        self.key = next(fields)
 
-      for key, value, nested in fields:
-          if key == "title":
-              # Title with no braces, tabs, nor linebreak and corrected blanks:
-              self.title = " ".join(re.sub("({|})", "", value).split())
+        for key, value, nested in fields:
+            if key == "title":
+                # Title with no braces, tabs, nor linebreak and corrected blanks:
+                self.title = " ".join(re.sub("({|})", "", value).split())
 
-          elif key == "author":
-              # Parse authors finding all non-brace-nested 'and' instances:
-              authors, nests = u.cond_split(value.replace("\n"," "), " and ",
-                                  nested=nested, ret_nests=True)
-              self.authors = [u.parse_name(author, nested)
-                              for author,nested in zip(authors,nests)]
+            elif key == "author":
+                # Parse authors finding all non-brace-nested 'and' instances:
+                authors, nests = u.cond_split(value.replace("\n"," "), " and ",
+                                    nested=nested, ret_nests=True)
+                self.authors = [u.parse_name(author, nested)
+                                for author,nested in zip(authors,nests)]
 
-          elif key == "year":
-              r = re.search('[0-9]{4}', value)
-              self.year = int(r.group(0))
+            elif key == "year":
+                r = re.search('[0-9]{4}', value)
+                self.year = int(r.group(0))
 
-          elif key == "month":
-              value = value.lower().strip()
-              self.month = months[value[0:3]]
+            elif key == "month":
+                value = value.lower().strip()
+                if value.isdigit():
+                    self.month = int(value)
+                else:
+                    self.month = months[value[0:3]]
 
-          elif key == "doi":
-              self.doi = value
+            elif key == "doi":
+                self.doi = value
 
-          elif key == "adsurl":
-              self.adsurl = value
-              # Get bibcode from adsurl, un-code UTF-8, and remove backslashes:
-              bibcode = os.path.split(value)[1].replace('\\', '')
-              self.bibcode = urllib.parse.unquote(bibcode)
+            elif key == "adsurl":
+                self.adsurl = value
+                # Get bibcode from adsurl, un-code UTF-8, and remove backslashes:
+                bibcode = os.path.split(value)[1].replace('\\', '')
+                self.bibcode = urllib.parse.unquote(bibcode)
 
-          elif key == "eprint":
-              self.eprint = value.replace('arXiv:','').replace('astro-ph/','')
+            elif key == "eprint":
+                self.eprint = value.replace('arXiv:','').replace('astro-ph/','')
 
-          elif key == "isbn":
-              self.isbn = value.lower().strip()
+            elif key == "isbn":
+                self.isbn = value.lower().strip()
 
-      for attr in ['authors', 'title', 'year']:
-          if not hasattr(self, attr):
-              raise ValueError(f"Bibtex entry '{self.key}' is missing author, "
-                                "title, or year.")
-      # First-author fields used for sorting:
-      # Note this differs from Author[0], since fields are 'purified',
-      # and 'first' goes only by initials().
-      self.sort_author = u.Sort_author(u.purify(self.authors[0].last),
-                                       u.initials(self.authors[0].first),
-                                       u.purify(self.authors[0].von),
-                                       u.purify(self.authors[0].jr),
-                                       self.year,
-                                       self.month)
+        for attr in ['authors', 'title', 'year']:
+            if not hasattr(self, attr):
+                raise ValueError(f"Bibtex entry '{self.key}' is missing author, "
+                                  "title, or year.")
+        # First-author fields used for sorting:
+        # Note this differs from Author[0], since fields are 'purified',
+        # and 'first' goes only by initials().
+        self.sort_author = u.Sort_author(u.purify(self.authors[0].last),
+                                         u.initials(self.authors[0].first),
+                                         u.purify(self.authors[0].von),
+                                         u.purify(self.authors[0].jr),
+                                         self.year,
+                                         self.month)
 
-  def update_key(self, new_key):
-      """Update key with new_key, making sure to also update content."""
-      self.content = self.content.replace(self.key, new_key, 1)
-      self.key = new_key
+    def update_key(self, new_key):
+        """Update key with new_key, making sure to also update content."""
+        self.content = self.content.replace(self.key, new_key, 1)
+        self.key = new_key
 
-  def __repr__(self):
-      return self.content
+    def __repr__(self):
+        return self.content
 
-  def __contains__(self, author):
-      r"""
-      Check if given author is in the author list of this bib entry.
-      If the 'author' string begins with the '^' character, match
-      only against the first author.
+    def __contains__(self, author):
+        r"""
+        Check if given author is in the author list of this bib entry.
+        If the 'author' string begins with the '^' character, match
+        only against the first author.
 
-      Parameters
-      ----------
-      author: String
-         An author name in a valid BibTeX format.
+        Parameters
+        ----------
+        author: String
+           An author name in a valid BibTeX format.
 
-      Examples
-      --------
-      >>> import bibmanager.bib_manager as bm
-      >>> bib = bm.Bib('''@ARTICLE{DoeEtal2020,
-                      author = {{Doe}, J. and {Perez}, J. and {Dupont}, J.},
-                       title = "What Have the Astromomers ever Done for Us?",
-                     journal = {\apj},
-                        year = 2020,}''')
-      >>> # Check for first author:
-      >>> 'Doe, J' in bib
-      True
-      >>> # Format doesn't matter, as long as it is a valid format:
-      >>> 'John Doe' in bib
-      True
-      >>> # Neglecting first's initials still match:
-      >>> 'Doe' in bib
-      True
-      >>> # But, non-matching initials wont match:
-      >>> 'Doe, K.' in bib
-      False
-      >>> # Match against first author only if string begins with '^':
-      >>> '^Doe' in bib
-      True
-      >>> '^Perez' in bib
-      False
-      """
-      # Check first-author mark:
-      if author[0:1] == '^':
-          author = author[1:]
-          authors = [self.authors[0]]
-      else:
-          authors = self.authors
-      # Parse and purify input author name:
-      author = u.parse_name(author)
-      first  = u.initials(author.first)
-      von    = u.purify(author.von)
-      last   = u.purify(author.last)
-      jr     = u.purify(author.jr)
-      # Remove non-matching authors by each non-empty field:
-      if len(jr) > 0:
-          authors = [author for author in authors if jr  == u.purify(author.jr)]
-      if len(von) > 0:
-          authors = [author for author in authors
-                     if von == u.purify(author.von)]
-      if len(first) > 0:
-          authors = [author for author in authors
-                     if first == u.initials(author.first)[0:len(first)]]
-      authors = [author for author in authors if last == u.purify(author.last)]
-      return len(authors) >= 1
+        Examples
+        --------
+        >>> import bibmanager.bib_manager as bm
+        >>> bib = bm.Bib('''@ARTICLE{DoeEtal2020,
+                        author = {{Doe}, J. and {Perez}, J. and {Dupont}, J.},
+                         title = "What Have the Astromomers ever Done for Us?",
+                       journal = {\apj},
+                          year = 2020,}''')
+        >>> # Check for first author:
+        >>> 'Doe, J' in bib
+        True
+        >>> # Format doesn't matter, as long as it is a valid format:
+        >>> 'John Doe' in bib
+        True
+        >>> # Neglecting first's initials still match:
+        >>> 'Doe' in bib
+        True
+        >>> # But, non-matching initials wont match:
+        >>> 'Doe, K.' in bib
+        False
+        >>> # Match against first author only if string begins with '^':
+        >>> '^Doe' in bib
+        True
+        >>> '^Perez' in bib
+        False
+        """
+        # Check first-author mark:
+        if author[0:1] == '^':
+            author = author[1:]
+            authors = [self.authors[0]]
+        else:
+            authors = self.authors
+        # Parse and purify input author name:
+        author = u.parse_name(author)
+        first  = u.initials(author.first)
+        von    = u.purify(author.von)
+        last   = u.purify(author.last)
+        jr     = u.purify(author.jr)
+        # Remove non-matching authors by each non-empty field:
+        if len(jr) > 0:
+            authors = [author for author in authors if jr  == u.purify(author.jr)]
+        if len(von) > 0:
+            authors = [author for author in authors
+                       if von == u.purify(author.von)]
+        if len(first) > 0:
+            authors = [author for author in authors
+                       if first == u.initials(author.first)[0:len(first)]]
+        authors = [author for author in authors if last == u.purify(author.last)]
+        return len(authors) >= 1
 
-  # https://docs.python.org/3.6/library/stdtypes.html
-  def __lt__(self, other):
-      """
-      Evaluate sequentially according to sort_author's fields: last,
-      first, von, and jr, year, and month.  If any of these
-      fields are equal, go on to next field to compare.
-      """
-      s, o = self.sort_author, other.sort_author
-      if s.last != o.last:
-          return s.last < o.last
-      if len(s.first)==1 or len(o.first) == 1:
-          if s.first[0:1] != o.first[0:1]:
-              return s.first < o.first
-      else:
-          if s.first != o.first:
-              return s.first < o.first
-      if s.von != o.von:
-          return s.von < o.von
-      if s.jr != o.jr:
-          return s.jr < o.jr
-      if s.year != o.year:
-          return s.year < o.year
-      return s.month < o.month
+    # https://docs.python.org/3.6/library/stdtypes.html
+    def __lt__(self, other):
+        """
+        Evaluate sequentially according to sort_author's fields: last,
+        first, von, and jr, year, and month.  If any of these
+        fields are equal, go on to next field to compare.
+        """
+        s, o = self.sort_author, other.sort_author
+        if s.last != o.last:
+            return s.last < o.last
+        if len(s.first)==1 or len(o.first) == 1:
+            if s.first[0:1] != o.first[0:1]:
+                return s.first < o.first
+        else:
+            if s.first != o.first:
+                return s.first < o.first
+        if s.von != o.von:
+            return s.von < o.von
+        if s.jr != o.jr:
+            return s.jr < o.jr
+        if s.year != o.year:
+            return s.year < o.year
+        return s.month < o.month
 
-  def __eq__(self, other):
-      """
-      Check whether self and other have same sort_author (first author)
-      and year/month.
-      Evaluate to equal by first initial if one entry has less initials
-      than the other.
-      """
-      if len(self.sort_author.first)==1 or len(other.sort_author.first)==1:
-          first = self.sort_author.first[0:1] == other.sort_author.first[0:1]
-      else:
-          first = self.sort_author.first == other.sort_author.first
+    def __eq__(self, other):
+        """
+        Check whether self and other have same sort_author (first author)
+        and year/month.
+        Evaluate to equal by first initial if one entry has less initials
+        than the other.
+        """
+        if len(self.sort_author.first)==1 or len(other.sort_author.first)==1:
+            first = self.sort_author.first[0:1] == other.sort_author.first[0:1]
+        else:
+            first = self.sort_author.first == other.sort_author.first
 
-      return (self.sort_author.last  == other.sort_author.last
-          and first
-          and self.sort_author.von   == other.sort_author.von
-          and self.sort_author.jr    == other.sort_author.jr
-          and self.sort_author.year  == other.sort_author.year
-          and self.sort_author.month == other.sort_author.month)
+        return (self.sort_author.last  == other.sort_author.last
+            and first
+            and self.sort_author.von   == other.sort_author.von
+            and self.sort_author.jr    == other.sort_author.jr
+            and self.sort_author.year  == other.sort_author.year
+            and self.sort_author.month == other.sort_author.month)
 
-  def __le__(self, other):
-      return self.__lt__(other) or self.__eq__(other)
+    def __le__(self, other):
+        return self.__lt__(other) or self.__eq__(other)
 
-  def published(self):
-      """
-      Published status according to the ADS bibcode field:
-         Return -1 if bibcode is None.
-         Return  0 if bibcode is arXiv.
-         Return  1 if bibcode is peer-reviewed journal.
-      """
-      if self.bibcode is None:
-          return -1
-      return int(self.bibcode.find('arXiv') < 0)
+    def published(self):
+        """
+        Published status according to the ADS bibcode field:
+           Return -1 if bibcode is None.
+           Return  0 if bibcode is arXiv.
+           Return  1 if bibcode is peer-reviewed journal.
+        """
+        if self.bibcode is None:
+            return -1
+        return int(self.bibcode.find('arXiv') < 0)
 
 
-  def get_authors(self, short=True):
-      """
-      wrapper for string representation for the author list.
-      See bib_manager.get_authors() for docstring.
-      """
-      return u.get_authors(self.authors, short)
+    def get_authors(self, short=True):
+        """
+        wrapper for string representation for the author list.
+        See bib_manager.get_authors() for docstring.
+        """
+        return u.get_authors(self.authors, short)
 
 
 def display_bibs(labels, bibs):
-  r"""
-  Display a list of bib entries on screen with flying colors.
+    r"""
+    Display a list of bib entries on screen with flying colors.
 
-  Parameters
-  ----------
-  labels: List of Strings
-     Header labels to show above each Bib() entry.
-  bibs: List of Bib() objects
-     BibTeX entries to display.
+    Parameters
+    ----------
+    labels: List of Strings
+       Header labels to show above each Bib() entry.
+    bibs: List of Bib() objects
+       BibTeX entries to display.
 
-  Examples
-  --------
-  >>> import bibmanager.bib_manager as bm
-  >>> e1 = '''@Misc{JonesEtal2001scipy,
-         author = {Eric Jones and Travis Oliphant and Pearu Peterson},
-         title  = {{SciPy}: Open source scientific tools for {Python}},
-         year   = {2001},
-       }'''
-  >>> e2 = '''@Misc{Jones2001,
-         author = {Eric Jones and Travis Oliphant and Pearu Peterson},
-         title  = {SciPy: Open source scientific tools for Python},
-         year   = {2001},
-       }'''
-  >>> bibs = [bm.Bib(e1), bm.Bib(e2)]
-  >>> bm.display_bibs(["DATABASE:\n", "NEW:\n"], bibs)
-  ::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
-  DATABASE:
-  @Misc{JonesEtal2001scipy,
-         author = {Eric Jones and Travis Oliphant and Pearu Peterson},
-         title  = {{SciPy}: Open source scientific tools for {Python}},
-         year   = {2001},
-       }
+    Examples
+    --------
+    >>> import bibmanager.bib_manager as bm
+    >>> e1 = '''@Misc{JonesEtal2001scipy,
+           author = {Eric Jones and Travis Oliphant and Pearu Peterson},
+           title  = {{SciPy}: Open source scientific tools for {Python}},
+           year   = {2001},
+         }'''
+    >>> e2 = '''@Misc{Jones2001,
+           author = {Eric Jones and Travis Oliphant and Pearu Peterson},
+           title  = {SciPy: Open source scientific tools for Python},
+           year   = {2001},
+         }'''
+    >>> bibs = [bm.Bib(e1), bm.Bib(e2)]
+    >>> bm.display_bibs(["DATABASE:\n", "NEW:\n"], bibs)
+    ::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
+    DATABASE:
+    @Misc{JonesEtal2001scipy,
+           author = {Eric Jones and Travis Oliphant and Pearu Peterson},
+           title  = {{SciPy}: Open source scientific tools for {Python}},
+           year   = {2001},
+         }
 
-  NEW:
-  @Misc{Jones2001,
-         author = {Eric Jones and Travis Oliphant and Pearu Peterson},
-         title  = {SciPy: Open source scientific tools for Python},
-         year   = {2001},
-       }
-  """
-  style = prompt_toolkit.styles.style_from_pygments_cls(
-              pygments.styles.get_style_by_name(cm.get('style')))
-  if labels is None:
-      labels = ["" for _ in bibs]
-  tokens = [(Token.Comment, u.BANNER)]
-  for label,bib in zip(labels, bibs):
-      tokens += [(Token.Text, label)]
-      tokens += list(pygments.lex(bib.content, lexer=BibTeXLexer()))
-      tokens += [(Token.Text, "\n")]
-  print_formatted_text(PygmentsTokens(tokens), end="", style=style)
+    NEW:
+    @Misc{Jones2001,
+           author = {Eric Jones and Travis Oliphant and Pearu Peterson},
+           title  = {SciPy: Open source scientific tools for Python},
+           year   = {2001},
+         }
+    """
+    style = prompt_toolkit.styles.style_from_pygments_cls(
+                pygments.styles.get_style_by_name(cm.get('style')))
+    if labels is None:
+        labels = ["" for _ in bibs]
+    tokens = [(Token.Comment, u.BANNER)]
+    for label,bib in zip(labels, bibs):
+        tokens += [(Token.Text, label)]
+        tokens += list(pygments.lex(bib.content, lexer=BibTeXLexer()))
+        tokens += [(Token.Text, "\n")]
+    print_formatted_text(PygmentsTokens(tokens), end="", style=style)
 
 
 def remove_duplicates(bibs, field):
-  """
-  Look for duplicates (within a same list of entries) by field and
-  remove them (in place).
+    """
+    Look for duplicates (within a same list of entries) by field and
+    remove them (in place).
 
-  Parameters
-  ----------
-  bibs: List of Bib() objects
-     Entries to filter.
-  field: String
-     Field to use for filtering ('doi', 'isbn', 'bibcode', or 'eprint').
-  """
-  fieldlist = [getattr(bib,field) if getattr(bib,field) is not None else ""
-               for bib in bibs]
-  # No entries:
-  if len(fieldlist) == 0:
-      return
+    Parameters
+    ----------
+    bibs: List of Bib() objects
+       Entries to filter.
+    field: String
+       Field to use for filtering ('doi', 'isbn', 'bibcode', or 'eprint').
+    """
+    fieldlist = [getattr(bib,field) if getattr(bib,field) is not None else ""
+                 for bib in bibs]
+    # No entries:
+    if len(fieldlist) == 0:
+        return
 
-  ubib, uinv, counts = np.unique(fieldlist, return_inverse=True,
-                                 return_counts=True)
-  multis = np.where((counts > 1) & (ubib != ""))[0]
+    ubib, uinv, counts = np.unique(fieldlist, return_inverse=True,
+                                   return_counts=True)
+    multis = np.where((counts > 1) & (ubib != ""))[0]
 
-  # No duplicates:
-  if len(multis) == 0:
-      return
+    # No duplicates:
+    if len(multis) == 0:
+        return
 
-  removes = []
-  for m in multis:
-      all_indices = np.where(uinv == m)[0]
-      entries = [bibs[i].content for i in all_indices]
+    removes = []
+    for m in multis:
+        all_indices = np.where(uinv == m)[0]
+        entries = [bibs[i].content for i in all_indices]
 
-      # Remove identical entries:
-      uentries, uidx = np.unique(entries, return_index=True)
-      indices = list(all_indices[uidx])
-      removes += [idx for idx in all_indices if idx not in indices]
-      nbibs = len(uentries)
-      if nbibs == 1:
-          continue
+        # Remove identical entries:
+        uentries, uidx = np.unique(entries, return_index=True)
+        indices = list(all_indices[uidx])
+        removes += [idx for idx in all_indices if idx not in indices]
+        nbibs = len(uentries)
+        if nbibs == 1:
+            continue
 
-      # Pick peer-reviewed over ArXiv over non-ADS:
-      pubs = [bibs[i].published() for i in indices]
-      pubmax = np.amax(pubs)
-      removes += [idx for idx,pub in zip(indices,pubs) if pub <  pubmax]
-      indices  = [idx for idx,pub in zip(indices,pubs) if pub == pubmax]
-      nbibs = len(indices)
-      if nbibs == 1:
-          continue
+        # Pick peer-reviewed over ArXiv over non-ADS:
+        pubs = [bibs[i].published() for i in indices]
+        pubmax = np.amax(pubs)
+        removes += [idx for idx,pub in zip(indices,pubs) if pub <  pubmax]
+        indices  = [idx for idx,pub in zip(indices,pubs) if pub == pubmax]
+        nbibs = len(indices)
+        if nbibs == 1:
+            continue
 
-      # Querry the user:
-      labels = [idx + " ENTRY:\n" for idx in u.ordinal(np.arange(nbibs)+1)]
-      display_bibs(labels, [bibs[i] for i in indices])
-      s = u.req_input(f"Duplicate {field} field, []keep first, [2]second, "
-           "[3]third, etc.: ", options=[""]+list(np.arange(nbibs)+1))
-      if s == "":
-          indices.pop(0)
-      else:
-          indices.pop(int(s)-1)
-      removes += indices
+        # Querry the user:
+        labels = [idx + " ENTRY:\n" for idx in u.ordinal(np.arange(nbibs)+1)]
+        display_bibs(labels, [bibs[i] for i in indices])
+        s = u.req_input(f"Duplicate {field} field, []keep first, [2]second, "
+             "[3]third, etc.: ", options=[""]+list(np.arange(nbibs)+1))
+        if s == "":
+            indices.pop(0)
+        else:
+            indices.pop(int(s)-1)
+        removes += indices
 
-  for idx in reversed(sorted(removes)):
-      bibs.pop(idx)
+    for idx in reversed(sorted(removes)):
+        bibs.pop(idx)
 
 
 def filter_field(bibs, new, field, take):
-  """
-  Filter duplicate entries by field between new and bibs.
-  This routine modifies new removing the duplicates, and may modify
-  bibs (depending on take argument).
+    """
+    Filter duplicate entries by field between new and bibs.
+    This routine modifies new removing the duplicates, and may modify
+    bibs (depending on take argument).
 
-  Parameters
-  ----------
-  bibs: List of Bib() objects
-     Database entries.
-  new: List of Bib() objects
-     New entries to add.
-  field: String
-     Field to use for filtering.
-  take: String
-     Decision-making protocol to resolve conflicts when there are
-     partially duplicated entries.
-     'old': Take the database entry over new.
-     'new': Take the new entry over the database.
-     'ask': Ask user to decide (interactively).
-  """
-  fields = [getattr(e,field)  for e in bibs]
-  removes = []
-  for i,e in enumerate(new):
-      if getattr(e,field) is None  or  getattr(e,field) not in fields:
-          continue
-      idx = fields.index(getattr(e,field))
-      # Replace if duplicate and new has newer bibcode:
-      if e.published() > bibs[idx].published() or take=='new':
-          bibs[idx] = e
-      # Look for different-key conflict:
-      if e.key != bibs[idx].key and take == "ask":
-          display_bibs(["DATABASE:\n", "NEW:\n"], [bibs[idx], e])
-          s = u.req_input(f"Duplicate {field} field but different keys, []keep "
-                           "database or take [n]ew: ", options=["", "n"])
-          if s == "n":
-              bibs[idx] = e
-      removes.append(i)
-  for idx in reversed(sorted(removes)):
-      new.pop(idx)
+    Parameters
+    ----------
+    bibs: List of Bib() objects
+       Database entries.
+    new: List of Bib() objects
+       New entries to add.
+    field: String
+       Field to use for filtering.
+    take: String
+       Decision-making protocol to resolve conflicts when there are
+       partially duplicated entries.
+       'old': Take the database entry over new.
+       'new': Take the new entry over the database.
+       'ask': Ask user to decide (interactively).
+    """
+    fields = [getattr(e,field)  for e in bibs]
+    removes = []
+    for i,e in enumerate(new):
+        if getattr(e,field) is None  or  getattr(e,field) not in fields:
+            continue
+        idx = fields.index(getattr(e,field))
+        # Replace if duplicate and new has newer bibcode:
+        if e.published() > bibs[idx].published() or take=='new':
+            bibs[idx] = e
+        # Look for different-key conflict:
+        if e.key != bibs[idx].key and take == "ask":
+            display_bibs(["DATABASE:\n", "NEW:\n"], [bibs[idx], e])
+            s = u.req_input(f"Duplicate {field} field but different keys, []keep "
+                             "database or take [n]ew: ", options=["", "n"])
+            if s == "n":
+                bibs[idx] = e
+        removes.append(i)
+    for idx in reversed(sorted(removes)):
+        new.pop(idx)
 
 
 def loadfile(bibfile=None, text=None):
-  """
-  Create a list of Bib() objects from a BibTeX file (.bib file).
+    """
+    Create a list of Bib() objects from a BibTeX file (.bib file).
 
-  Parameters
-  ----------
-  bibfile: String
-     Path to an existing .bib file.
-  text: String
-     Content of a .bib file (ignored if bibfile is not None).
+    Parameters
+    ----------
+    bibfile: String
+       Path to an existing .bib file.
+    text: String
+       Content of a .bib file (ignored if bibfile is not None).
 
-  Returns
-  -------
-  bibs: List of Bib() objects
-     List of Bib() objects of BibTeX entries in bibfile, sorted by
-     Sort_author() fields.
+    Returns
+    -------
+    bibs: List of Bib() objects
+       List of Bib() objects of BibTeX entries in bibfile, sorted by
+       Sort_author() fields.
 
-  Examples
-  --------
-  >>> import bibmanager.bib_manager as bm
-  >>> import os
-  >>> bibfile = os.path.expanduser("~") + "/.bibmanager/examples/sample.bib"
-  >>> bibs = bm.loadfile(bibfile)
-  """
-  entries = []  # Store Lists of bibtex entries
-  entry   = []  # Store lines in the bibtex
-  parcount = 0
+    Examples
+    --------
+    >>> import bibmanager.bib_manager as bm
+    >>> import os
+    >>> bibfile = os.path.expanduser("~") + "/.bibmanager/examples/sample.bib"
+    >>> bibs = bm.loadfile(bibfile)
+    """
+    entries = []  # Store Lists of bibtex entries
+    entry   = []  # Store lines in the bibtex
+    parcount = 0
 
-  # Load a bib file:
-  if bibfile is not None:
-      f = open(bibfile, 'r')
-  elif text is not None:
-      f = text.splitlines()
-  else:
-      raise TypeError("Missing input arguments for loadfile(), at least "
-                      "bibfile or text must be provided.")
+    # Load a bib file:
+    if bibfile is not None:
+        f = open(bibfile, 'r')
+    elif text is not None:
+        f = text.splitlines()
+    else:
+        raise TypeError("Missing input arguments for loadfile(), at least "
+                        "bibfile or text must be provided.")
 
-  for i,line in enumerate(f):
-      # New entry:
-      if line.startswith("@") and parcount != 0:
-          raise ValueError(f"Mismatched braces in line {i}:\n'{line.rstrip()}'")
+    for i,line in enumerate(f):
+        # New entry:
+        if line.startswith("@") and parcount != 0:
+            raise ValueError(f"Mismatched braces in line {i}:\n'{line.rstrip()}'")
 
-      parcount += u.count(line)
-      if parcount == 0 and entry == []:
-          continue
+        parcount += u.count(line)
+        if parcount == 0 and entry == []:
+            continue
 
-      if parcount < 0:
-          raise ValueError(f"Mismatched braces in line {i}:\n'{line.rstrip()}'")
+        if parcount < 0:
+            raise ValueError(f"Mismatched braces in line {i}:\n'{line.rstrip()}'")
 
-      entry.append(line.rstrip())
+        entry.append(line.rstrip())
 
-      if parcount == 0 and entry != []:
-          entries.append("\n".join(entry))
-          entry = []
+        if parcount == 0 and entry != []:
+            entries.append("\n".join(entry))
+            entry = []
 
-  if bibfile is not None:
-      f.close()
+    if bibfile is not None:
+        f.close()
 
-  if parcount != 0:
-      raise ValueError("Invalid input, mistmatched braces at end of file.")
+    if parcount != 0:
+        raise ValueError("Invalid input, mistmatched braces at end of file.")
 
-  bibs = [Bib(entry) for entry in entries]
+    bibs = [Bib(entry) for entry in entries]
 
-  remove_duplicates(bibs, "doi")
-  remove_duplicates(bibs, "isbn")
-  remove_duplicates(bibs, "bibcode")
-  remove_duplicates(bibs, "eprint")
+    remove_duplicates(bibs, "doi")
+    remove_duplicates(bibs, "isbn")
+    remove_duplicates(bibs, "bibcode")
+    remove_duplicates(bibs, "eprint")
 
-  return sorted(bibs)
+    return sorted(bibs)
 
 
 def save(entries):
-  """
-  Save list of Bib() entries into bibmanager pickle database.
+    """
+    Save list of Bib() entries into bibmanager pickle database.
 
-  Parameters
-  ----------
-  entries: List of Bib() objects
-     bib files to store.
+    Parameters
+    ----------
+    entries: List of Bib() objects
+       bib files to store.
 
-  Examples
-  --------
-  >>> import bibmanager.bib_manager as bm
-  >>> # TBD: Load some entries
-  >>> bm.save(entries)
-  """
-  # FINDME: Don't pickle-save the Bib() objects directly, but store them
-  #      as dict objects. (More standard / backward compatibility)
-  with open(u.BM_DATABASE, 'wb') as handle:
-      pickle.dump(entries, handle, protocol=pickle.HIGHEST_PROTOCOL)
+    Examples
+    --------
+    >>> import bibmanager.bib_manager as bm
+    >>> # TBD: Load some entries
+    >>> bm.save(entries)
+    """
+    # FINDME: Don't pickle-save the Bib() objects directly, but store them
+    #      as dict objects. (More standard / backward compatibility)
+    with open(u.BM_DATABASE, 'wb') as handle:
+        pickle.dump(entries, handle, protocol=pickle.HIGHEST_PROTOCOL)
 
 
-def load():
-  """
-  Load the bibmanager database of BibTeX entries.
+  def load():
+    """
+    Load the bibmanager database of BibTeX entries.
 
-  Returns
-  -------
-  List of Bib() entries.  Return an empty list if there is no database
-  file.
+    Returns
+    -------
+    List of Bib() entries.  Return an empty list if there is no database
+    file.
 
-  Examples
-  --------
-  >>> import bibmanager.bib_manager as bm
-  >>> bibs = bm.load()
-  """
-  try:
-      with open(u.BM_DATABASE, 'rb') as handle:
-          return pickle.load(handle)
-  except:
-      # TBD: I think I'm not defaulting to this case anymore, I should
-      # let it break if the input file does not exist
-      return []
+    Examples
+    --------
+    >>> import bibmanager.bib_manager as bm
+    >>> bibs = bm.load()
+    """
+    try:
+        with open(u.BM_DATABASE, 'rb') as handle:
+            return pickle.load(handle)
+    except:
+        # TBD: I think I'm not defaulting to this case anymore, I should
+        # let it break if the input file does not exist
+        return []
 
 
 def export(entries, bibfile=u.BM_BIBFILE):
-  """
-  Export list of Bib() entries into a .bib file.
+    """
+    Export list of Bib() entries into a .bib file.
 
-  Parameters
-  ----------
-  entries: List of Bib() objects
-     Entries to export.
-  bibfile: String
-     Output .bib file name.
-  """
-  # Header for identification purposes:
-  header = ['This file was created by bibmanager\n',
-            'https://pcubillos.github.io/bibmanager/\n\n']
-  # Care not to overwrite user's bib files:
-  if os.path.exists(bibfile):
-      with open(bibfile, 'r') as f:
-          head = f.readline()
-      if head.strip() != header[0].strip():
-          path, bfile = os.path.split(os.path.realpath(bibfile))
-          shutil.copy(bibfile, "".join([path, '/orig_',
-                                     str(datetime.date.today()), '_', bfile]))
-  with open(bibfile, 'w') as f:
-      f.writelines(header)
-      for e in entries:
-          f.write(e.content)
-          f.write("\n\n")
+    Parameters
+    ----------
+    entries: List of Bib() objects
+       Entries to export.
+    bibfile: String
+       Output .bib file name.
+    """
+    # Header for identification purposes:
+    header = ['This file was created by bibmanager\n',
+              'https://pcubillos.github.io/bibmanager/\n\n']
+    # Care not to overwrite user's bib files:
+    if os.path.exists(bibfile):
+        with open(bibfile, 'r') as f:
+            head = f.readline()
+        if head.strip() != header[0].strip():
+            path, bfile = os.path.split(os.path.realpath(bibfile))
+            shutil.copy(bibfile, "".join([path, '/orig_',
+                                       str(datetime.date.today()), '_', bfile]))
+    with open(bibfile, 'w') as f:
+        f.writelines(header)
+        for e in entries:
+            f.write(e.content)
+            f.write("\n\n")
 
 
 def merge(bibfile=None, new=None, take="old", base=None):
-  """
-  Merge entries from a new bibfile into the bibmanager database
-  (or into an input database).
+    """
+    Merge entries from a new bibfile into the bibmanager database
+    (or into an input database).
 
-  Parameters
-  ----------
-  bibfile: String
-      New .bib file to merge into the bibmanager database.
-  new: List of Bib() objects
-      List of new BibTeX entries (ignored if bibfile is not None).
-  take: String
-      Decision-making protocol to resolve conflicts when there are
-      partially duplicated entries.
-      'old': Take the database entry over new.
-      'new': Take the new entry over the database.
-      'ask': Ask user to decide (interactively).
-  base: List of Bib() objects
-      If None, merge new entries into the bibmanager database.
-      If not None, merge new intries into base.
+    Parameters
+    ----------
+    bibfile: String
+        New .bib file to merge into the bibmanager database.
+    new: List of Bib() objects
+        List of new BibTeX entries (ignored if bibfile is not None).
+    take: String
+        Decision-making protocol to resolve conflicts when there are
+        partially duplicated entries.
+        'old': Take the database entry over new.
+        'new': Take the new entry over the database.
+        'ask': Ask user to decide (interactively).
+    base: List of Bib() objects
+        If None, merge new entries into the bibmanager database.
+        If not None, merge new intries into base.
 
-  Returns
-  -------
-  bibs: List of Bib() objects
-      Merged list of BibTeX entries.
+    Returns
+    -------
+    bibs: List of Bib() objects
+        Merged list of BibTeX entries.
 
-  Examples
-  --------
-  >>> import bibmanager.bib_manager as bm
-  >>> import os
-  >>> # TBD: Need to add sample2.bib into package.
-  >>> newbib = os.path.expanduser("~") + "/.bibmanager/examples/sample2.bib"
-  >>> # Merge newbib into database:
-  >>> bm.merge(newbib, take='old')
-  """
-  if base is None:
-      bibs = load()
-  else:
-      bibs = base
+    Examples
+    --------
+    >>> import bibmanager.bib_manager as bm
+    >>> import os
+    >>> # TBD: Need to add sample2.bib into package.
+    >>> newbib = os.path.expanduser("~") + "/.bibmanager/examples/sample2.bib"
+    >>> # Merge newbib into database:
+    >>> bm.merge(newbib, take='old')
+    """
+    if base is None:
+        bibs = load()
+    else:
+        bibs = base
 
-  if bibfile is not None:
-      new = loadfile(bibfile)
-  if new is None:
-      return
+    if bibfile is not None:
+        new = loadfile(bibfile)
+    if new is None:
+        return
 
-  # Filter duplicates by field:
-  filter_field(bibs, new, "doi",     take)
-  filter_field(bibs, new, "isbn",    take)
-  filter_field(bibs, new, "bibcode", take)
-  filter_field(bibs, new, "eprint",  take)
+    # Filter duplicates by field:
+    filter_field(bibs, new, "doi",     take)
+    filter_field(bibs, new, "isbn",    take)
+    filter_field(bibs, new, "bibcode", take)
+    filter_field(bibs, new, "eprint",  take)
 
-  # Filter duplicate key:
-  keep = np.zeros(len(new), bool)
-  bm_keys = [e.key for e in bibs]
-  for i,e in enumerate(new):
-      if e.key not in bm_keys:
-          keep[i] = True
-          continue
-      idx = bm_keys.index(e.key)
-      if e.content == bibs[idx].content:
-          continue # Duplicate, do not take
-      else:
-          display_bibs(["DATABASE:\n", "NEW:\n"], [bibs[idx], e])
-          s = input("Duplicate key but content differ, []ignore new, "
-                    "take [n]ew, or\nrename key of new entry: ")
-          if s == "n":
-              bibs[idx] = e
-          elif s != "":
-              new[i].key = s
-              new[i].content.replace(e.key, s)
-              keep[i] = True
-  new = [e for e,keeper in zip(new,keep) if keeper]
+    # Filter duplicate key:
+    keep = np.zeros(len(new), bool)
+    bm_keys = [e.key for e in bibs]
+    for i,e in enumerate(new):
+        if e.key not in bm_keys:
+            keep[i] = True
+            continue
+        idx = bm_keys.index(e.key)
+        if e.content == bibs[idx].content:
+            continue # Duplicate, do not take
+        else:
+            display_bibs(["DATABASE:\n", "NEW:\n"], [bibs[idx], e])
+            s = input("Duplicate key but content differ, []ignore new, "
+                      "take [n]ew, or\nrename key of new entry: ")
+            if s == "n":
+                bibs[idx] = e
+            elif s != "":
+                new[i].key = s
+                new[i].content.replace(e.key, s)
+                keep[i] = True
+    new = [e for e,keeper in zip(new,keep) if keeper]
 
-  # Different key, same title:
-  keep = np.zeros(len(new), bool)
-  bm_titles = [e.title for e in bibs]
-  for i,e in enumerate(new):
-      if e.title not in bm_titles:
-          keep[i] = True
-          continue
-      idx = bm_titles.index(e.title)
-      display_bibs(["DATABASE:\n", "NEW:\n"], [bibs[idx], e])
-      s = u.req_input("Possible duplicate, same title but keys differ, "
-                      "[]ignore new, [r]eplace database with new, "
-                      "or [a]dd new: ", options=["", "r", "a"])
-      if s == "r":
-          bibs[idx] = e
-      elif s == "a":
-          keep[i] = True
-  new = [e for e,keeper in zip(new,keep) if keeper]
+    # Different key, same title:
+    keep = np.zeros(len(new), bool)
+    bm_titles = [e.title for e in bibs]
+    for i,e in enumerate(new):
+        if e.title not in bm_titles:
+            keep[i] = True
+            continue
+        idx = bm_titles.index(e.title)
+        display_bibs(["DATABASE:\n", "NEW:\n"], [bibs[idx], e])
+        s = u.req_input("Possible duplicate, same title but keys differ, "
+                        "[]ignore new, [r]eplace database with new, "
+                        "or [a]dd new: ", options=["", "r", "a"])
+        if s == "r":
+            bibs[idx] = e
+        elif s == "a":
+            keep[i] = True
+    new = [e for e,keeper in zip(new,keep) if keeper]
 
-  # Add all new entries and sort:
-  bibs = sorted(bibs + new)
-  print(f"\nMerged {len(new)} new entries.")
+    # Add all new entries and sort:
+    bibs = sorted(bibs + new)
+    print(f"\nMerged {len(new)} new entries.")
 
-  if base is None:
-      save(bibs)
-      export(bibs)
+    if base is None:
+        save(bibs)
+        export(bibs)
 
-  return bibs
+    return bibs
 
 
 def init(bibfile=u.BM_BIBFILE, reset_db=True, reset_config=False):
-  """
-  Initialize bibmanager, reset database entries and config parameters.
+    """
+    Initialize bibmanager, reset database entries and config parameters.
 
-  Parameters
-  ----------
-  bibfile: String
-     A bibfile to include as the new bibmanager database.
-     If None, reset the bibmanager database with a clean slate.
-  reset_db: Bool
-     If True, reset the bibmanager database.
-  reset_config: Bool
-     If True, reset the config file.
+    Parameters
+    ----------
+    bibfile: String
+       A bibfile to include as the new bibmanager database.
+       If None, reset the bibmanager database with a clean slate.
+    reset_db: Bool
+       If True, reset the bibmanager database.
+    reset_config: Bool
+       If True, reset the config file.
 
-  Examples
-  --------
-  >>> import bibmanager.bib_manager as bm
-  >>> import os
-  >>> bibfile = os.path.expanduser("~") + "/.bibmanager/examples/sample.bib"
-  >>> bm.init(bibfile)
-  """
-  # First install ever:
-  if not os.path.exists(u.HOME):
-      os.mkdir(u.HOME)
+    Examples
+    --------
+    >>> import bibmanager.bib_manager as bm
+    >>> import os
+    >>> bibfile = os.path.expanduser("~") + "/.bibmanager/examples/sample.bib"
+    >>> bm.init(bibfile)
+    """
+    # First install ever:
+    if not os.path.exists(u.HOME):
+        os.mkdir(u.HOME)
 
-  # Copy examples folder:
-  shutil.rmtree(u.HOME+'examples/', True)
-  shutil.copytree(u.ROOT+'examples/', u.HOME+'examples/')
+    # Copy examples folder:
+    shutil.rmtree(u.HOME+'examples/', True)
+    shutil.copytree(u.ROOT+'examples/', u.HOME+'examples/')
 
-  # Make sure config exists before working with the database:
-  if reset_config:
-      shutil.copy(u.ROOT+'config', u.HOME+'config')
-  else:
-      cm.update_keys()
+    # Make sure config exists before working with the database:
+    if reset_config:
+        shutil.copy(u.ROOT+'config', u.HOME+'config')
+    else:
+        cm.update_keys()
 
-  if reset_db:
-      if bibfile is None:
-          with u.ignored(OSError):
-              os.remove(u.BM_DATABASE)
-              os.remove(u.BM_BIBFILE)
-      else:
-          bibs = loadfile(bibfile)
-          save(bibs)
-          export(bibs)
+    if reset_db:
+        if bibfile is None:
+            with u.ignored(OSError):
+                os.remove(u.BM_DATABASE)
+                os.remove(u.BM_BIBFILE)
+        else:
+            bibs = loadfile(bibfile)
+            save(bibs)
+            export(bibs)
 
 
-def add_entries(take='ask'):
-  """
-  Manually add BibTeX entries through the prompt.
+  def add_entries(take='ask'):
+    """
+    Manually add BibTeX entries through the prompt.
 
-  Parameters
-  ----------
-  take: String
-     Decision-making protocol to resolve conflicts when there are
-     partially duplicated entries.
-     'old': Take the database entry over new.
-     'new': Take the new entry over the database.
-     'ask': Ask user to decide (interactively).
-  """
-  style = prompt_toolkit.styles.style_from_pygments_cls(
-              pygments.styles.get_style_by_name(cm.get('style')))
-  newbibs = prompt_toolkit.prompt(
-      "Enter a BibTeX entry (press META+ENTER or ESCAPE ENTER when done):\n",
-      multiline=True, lexer=lexer, style=style)
-  new = loadfile(text=newbibs)
+    Parameters
+    ----------
+    take: String
+       Decision-making protocol to resolve conflicts when there are
+       partially duplicated entries.
+       'old': Take the database entry over new.
+       'new': Take the new entry over the database.
+       'ask': Ask user to decide (interactively).
+    """
+    style = prompt_toolkit.styles.style_from_pygments_cls(
+                pygments.styles.get_style_by_name(cm.get('style')))
+    newbibs = prompt_toolkit.prompt(
+        "Enter a BibTeX entry (press META+ENTER or ESCAPE ENTER when done):\n",
+        multiline=True, lexer=lexer, style=style)
+    new = loadfile(text=newbibs)
 
-  if len(new) == 0:
-      print("No new entries to add.")
-      return
+    if len(new) == 0:
+        print("No new entries to add.")
+        return
 
-  merge(new=new, take=take)
+    merge(new=new, take=take)
 
 
 def edit():
-  """
-  Manually edit the bibfile database in text editor.
+    """
+    Manually edit the bibfile database in text editor.
 
-  Resources
-  ---------
-  https://stackoverflow.com/questions/17317219/
-  https://docs.python.org/3.6/library/subprocess.html
-  """
-  export(load(), u.BM_TMP_BIB)
-  # Open database.bib into temporary file with default text editor
-  if sys.platform == "win32":
-      os.startfile(u.BM_TMP_BIB)
-  else:
-      opener = cm.get('text_editor')
-      if opener == 'default':
-          opener = "open" if sys.platform == "darwin" else "xdg-open"
-      subprocess.call([opener, u.BM_TMP_BIB])
-  # Launch input() call to wait for user to save edits:
-  dummy = input("Press ENTER to continue after you edit, save, and close "
-                "the bib file.")
-  # Check edits:
-  try:
-      new = loadfile(u.BM_TMP_BIB)
-  finally:
-      # Always delete the tmp file:
-      os.remove(u.BM_TMP_BIB)
-  # Update database if everything went fine:
-  save(new)
-  export(new)
+    Resources
+    ---------
+    https://stackoverflow.com/questions/17317219/
+    https://docs.python.org/3.6/library/subprocess.html
+    """
+    export(load(), u.BM_TMP_BIB)
+    # Open database.bib into temporary file with default text editor
+    if sys.platform == "win32":
+        os.startfile(u.BM_TMP_BIB)
+    else:
+        opener = cm.get('text_editor')
+        if opener == 'default':
+            opener = "open" if sys.platform == "darwin" else "xdg-open"
+        subprocess.call([opener, u.BM_TMP_BIB])
+    # Launch input() call to wait for user to save edits:
+    dummy = input("Press ENTER to continue after you edit, save, and close "
+                  "the bib file.")
+    # Check edits:
+    try:
+        new = loadfile(u.BM_TMP_BIB)
+    finally:
+        # Always delete the tmp file:
+        os.remove(u.BM_TMP_BIB)
+    # Update database if everything went fine:
+    save(new)
+    export(new)
 
 
 def search(authors=None, year=None, title=None, key=None, bibcode=None):
-  """
-  Search in bibmanager database by authors, year, or title keywords.
+    """
+    Search in bibmanager database by authors, year, or title keywords.
 
-  Parameters
-  ----------
-  authors: String or List of strings
-     An author name (or list of names) with BibTeX format (see parse_name()
-     docstring).  To restrict search to a first author, prepend the
-     '^' character to a name.
-  year: Integer or two-element integer tuple
-     If integer, match against year; if tuple, minimum and maximum
-     matching years (including).
-  title: String or iterable (list, tuple, or ndarray of strings)
-     Match entries that contain all input strings in the title (ignore case).
-  key: String or list of strings
-     Match any entry whose key is in the input key.
-  bibcode: String or list of strings
-     Match any entry whose bibcode is in the input bibcode.
+    Parameters
+    ----------
+    authors: String or List of strings
+       An author name (or list of names) with BibTeX format (see parse_name()
+       docstring).  To restrict search to a first author, prepend the
+       '^' character to a name.
+    year: Integer or two-element integer tuple
+       If integer, match against year; if tuple, minimum and maximum
+       matching years (including).
+    title: String or iterable (list, tuple, or ndarray of strings)
+       Match entries that contain all input strings in the title (ignore case).
+    key: String or list of strings
+       Match any entry whose key is in the input key.
+    bibcode: String or list of strings
+       Match any entry whose bibcode is in the input bibcode.
 
-  Returns
-  -------
-  matches: List of Bib() objects
-     Entries that match all input criteria.
+    Returns
+    -------
+    matches: List of Bib() objects
+       Entries that match all input criteria.
 
-  Examples
-  --------
-  >>> import bibmanager.bib_manager as bm
-  >>> # Search by last name:
-  >>> matches = bm.search(authors="Cubillos")
-  >>> # Search by last name and initial:
-  >>> matches = bm.search(authors="Cubillos, P")
-  >>> # Search by author in given year:
-  >>> matches = bm.search(authors="Cubillos, P", year=2017)
-  >>> # Search by first author and co-author (using AND logic):
-  >>> matches = bm.search(authors=["^Cubillos", "Blecic"])
-  >>> # Search by keyword in title:
-  >>> matches = bm.search(title="Spitzer")
-  >>> # Search by keywords in title (using AND logic):
-  >>> matches = bm.search(title=["HD 189", "HD 209"])
-  >>> # Search by key (note that unlike the other fields, key and
-  >>> # bibcode use OR logic, so you can get many items at once):
-  >>> matches = bm.search(key="Astropycollab2013aaAstropy")
-  >>> # Search by bibcode (note no need to worry about UTF-8 encoding):
-  >>> matches = bm.search(bibcode=["2013A%26A...558A..33A",
-  >>>                              "1957RvMP...29..547B",
-  >>>                              "2017AJ....153....3C"])
-  """
-  matches = load()
-  if year is not None:
-      try: # Assume year = [from_year, to_year]
-          matches = [bib for bib in matches if bib.year >= year[0]]
-          matches = [bib for bib in matches if bib.year <= year[1]]
-      except:
-          matches = [bib for bib in matches if bib.year == year]
+    Examples
+    --------
+    >>> import bibmanager.bib_manager as bm
+    >>> # Search by last name:
+    >>> matches = bm.search(authors="Cubillos")
+    >>> # Search by last name and initial:
+    >>> matches = bm.search(authors="Cubillos, P")
+    >>> # Search by author in given year:
+    >>> matches = bm.search(authors="Cubillos, P", year=2017)
+    >>> # Search by first author and co-author (using AND logic):
+    >>> matches = bm.search(authors=["^Cubillos", "Blecic"])
+    >>> # Search by keyword in title:
+    >>> matches = bm.search(title="Spitzer")
+    >>> # Search by keywords in title (using AND logic):
+    >>> matches = bm.search(title=["HD 189", "HD 209"])
+    >>> # Search by key (note that unlike the other fields, key and
+    >>> # bibcode use OR logic, so you can get many items at once):
+    >>> matches = bm.search(key="Astropycollab2013aaAstropy")
+    >>> # Search by bibcode (note no need to worry about UTF-8 encoding):
+    >>> matches = bm.search(bibcode=["2013A%26A...558A..33A",
+    >>>                              "1957RvMP...29..547B",
+    >>>                              "2017AJ....153....3C"])
+    """
+    matches = load()
+    if year is not None:
+        try: # Assume year = [from_year, to_year]
+            matches = [bib for bib in matches if bib.year >= year[0]]
+            matches = [bib for bib in matches if bib.year <= year[1]]
+        except:
+            matches = [bib for bib in matches if bib.year == year]
 
-  if authors is not None:
-      if isinstance(authors, str):
-          authors = [authors]
-      elif not isinstance(authors, (list, tuple, np.ndarray)):
-          raise ValueError("Invalid input format for 'authors'.")
-      for author in authors:
-          matches = [bib for bib in matches if author in bib]
+    if authors is not None:
+        if isinstance(authors, str):
+            authors = [authors]
+        elif not isinstance(authors, (list, tuple, np.ndarray)):
+            raise ValueError("Invalid input format for 'authors'.")
+        for author in authors:
+            matches = [bib for bib in matches if author in bib]
 
-  if title is not None:
-      if isinstance(title, str):
-          title = [title]
-      elif not isinstance(title, (list, tuple, np.ndarray)):
-          raise ValueError("Invalid input format for 'title'.")
-      for word in title:
-          matches = [bib for bib in matches
-                     if word.lower() in bib.title.lower()]
+    if title is not None:
+        if isinstance(title, str):
+            title = [title]
+        elif not isinstance(title, (list, tuple, np.ndarray)):
+            raise ValueError("Invalid input format for 'title'.")
+        for word in title:
+            matches = [bib for bib in matches
+                       if word.lower() in bib.title.lower()]
 
-  if key is not None:
-      if isinstance(key, str):
-          key = [key]
-      elif not isinstance(key, (list, tuple, np.ndarray)):
-          raise ValueError("Invalid input format for 'key'.")
-      matches = [bib for bib in matches if bib.key in key]
+    if key is not None:
+        if isinstance(key, str):
+            key = [key]
+        elif not isinstance(key, (list, tuple, np.ndarray)):
+            raise ValueError("Invalid input format for 'key'.")
+        matches = [bib for bib in matches if bib.key in key]
 
-  if bibcode is not None:
-      if isinstance(bibcode, str):
-          bibcode = [bibcode]
-      elif not isinstance(bibcode, (list, tuple, np.ndarray)):
-          raise ValueError("Invalid input format for 'bibcode'.")
-      # Take care of encoding:
-      bibcode = [urllib.parse.unquote(b) for b in bibcode]
-      matches = [bib for bib in matches if bib.bibcode in bibcode]
+    if bibcode is not None:
+        if isinstance(bibcode, str):
+            bibcode = [bibcode]
+        elif not isinstance(bibcode, (list, tuple, np.ndarray)):
+            raise ValueError("Invalid input format for 'bibcode'.")
+        # Take care of encoding:
+        bibcode = [urllib.parse.unquote(b) for b in bibcode]
+        matches = [bib for bib in matches if bib.bibcode in bibcode]
 
-  return matches
+    return matches

--- a/bibmanager/bib_manager/bib_manager.py
+++ b/bibmanager/bib_manager/bib_manager.py
@@ -730,7 +730,7 @@ def init(bibfile=u.BM_BIBFILE, reset_db=True, reset_config=False):
             export(bibs)
 
 
-  def add_entries(take='ask'):
+def add_entries(take='ask'):
     """
     Manually add BibTeX entries through the prompt.
 

--- a/bibmanager/bib_manager/bib_manager.py
+++ b/bibmanager/bib_manager/bib_manager.py
@@ -530,7 +530,7 @@ def save(entries):
         pickle.dump(entries, handle, protocol=pickle.HIGHEST_PROTOCOL)
 
 
-  def load():
+def load():
     """
     Load the bibmanager database of BibTeX entries.
 

--- a/bibmanager/config_manager/config_manager.py
+++ b/bibmanager/config_manager/config_manager.py
@@ -17,193 +17,193 @@ styles = textwrap.fill(", ".join(style for style in iter(STYLE_MAP)),
 
 
 def help(key):
-  """
-  Display help information.
+    """
+    Display help information.
 
-  Parameters
-  ----------
-  key: String
-     A bibmanager config parameter.
-  """
-  if key == 'style':
-      print(f"\nThe '{key}' parameter sets the color-syntax style of displayed "
-             "BibTeX entries.\nThe default style is 'autumn'.  "
-            f"Available options are:\n{styles}\n"
-             "See http://pygments.org/demo/6780986/ for a demo of the style "
-             "options.\n\n"
-            f"The current style is '{get(key)}'.")
+    Parameters
+    ----------
+    key: String
+       A bibmanager config parameter.
+    """
+    if key == 'style':
+        print(f"\nThe '{key}' parameter sets the color-syntax style of displayed "
+               "BibTeX entries.\nThe default style is 'autumn'.  "
+              f"Available options are:\n{styles}\n"
+               "See http://pygments.org/demo/6780986/ for a demo of the style "
+               "options.\n\n"
+              f"The current style is '{get(key)}'.")
 
-  elif key == 'text_editor':
-      print(f"\nThe '{key}' parameter sets the text editor to use when editing "
-             "the\nbibmanager manually (i.e., a call to: bibm edit).  By "
-             "default, bibmanager\nuses the OS-default text editor.\n\n"
-             "Typical text editors are: emacs, vim, gedit.\n"
-             "To set the OS-default editor, set text_editor to 'default'.\n"
-             "Note that aliases defined in the .bash are not accessible.\n\n"
-            f"The current text editor is '{get(key)}'.")
+    elif key == 'text_editor':
+        print(f"\nThe '{key}' parameter sets the text editor to use when editing "
+               "the\nbibmanager manually (i.e., a call to: bibm edit).  By "
+               "default, bibmanager\nuses the OS-default text editor.\n\n"
+               "Typical text editors are: emacs, vim, gedit.\n"
+               "To set the OS-default editor, set text_editor to 'default'.\n"
+               "Note that aliases defined in the .bash are not accessible.\n\n"
+              f"The current text editor is '{get(key)}'.")
 
-  elif key == 'paper':
-      print(f"\nThe '{key}' parameter sets the default paper format for latex "
-             "compilation outputs\n(not for pdflatex, which is automatic).  "
-             "Typical options are 'letter'\n(e.g., for ApJ articles) or 'A4' "
-            f"(e.g., for A&A).\n\nThe current paper format is: '{get(key)}'.")
+    elif key == 'paper':
+        print(f"\nThe '{key}' parameter sets the default paper format for latex "
+               "compilation outputs\n(not for pdflatex, which is automatic).  "
+               "Typical options are 'letter'\n(e.g., for ApJ articles) or 'A4' "
+              f"(e.g., for A&A).\n\nThe current paper format is: '{get(key)}'.")
 
-  elif key == 'ads_token':
-      print(f"\nThe '{key}' parameter sets the ADS token required for ADS "
-             "requests.\nTo obtain a token, follow the steps described here:\n"
-             "  https://github.com/adsabs/adsabs-dev-api#access\n\n"
-            f"The current ADS token is '{get(key)}'")
+    elif key == 'ads_token':
+        print(f"\nThe '{key}' parameter sets the ADS token required for ADS "
+               "requests.\nTo obtain a token, follow the steps described here:\n"
+               "  https://github.com/adsabs/adsabs-dev-api#access\n\n"
+              f"The current ADS token is '{get(key)}'")
 
-  elif key == 'ads_display':
-      print(f"\nThe '{key}' parameter sets the number of entries to show at "
-             "a time,\nfor an ADS search querry.\n\n"
-            f"The current number of entries to display is {get(key)}.")
-  else:
-      # Call get() to trigger exception:
-      get(key)
+    elif key == 'ads_display':
+        print(f"\nThe '{key}' parameter sets the number of entries to show at "
+               "a time,\nfor an ADS search querry.\n\n"
+              f"The current number of entries to display is {get(key)}.")
+    else:
+        # Call get() to trigger exception:
+        get(key)
 
 
 def display(key=None):
-  """
-  Display the value(s) of the bibmanager config file on the prompt.
+    """
+    Display the value(s) of the bibmanager config file on the prompt.
 
-  Parameters
-  ----------
-  key: String
-     bibmanager config parameter to display.  Leave as None to display the
-     values from all parameters.
+    Parameters
+    ----------
+    key: String
+       bibmanager config parameter to display.  Leave as None to display the
+       values from all parameters.
 
-  Examples
-  --------
-  >>> import bibmanager.config_manager as cm
-  >>> # Show all parameters and values:
-  >>> cm.display()
-  bibmanager configuration file:
-  PARAMETER    VALUE
-  -----------  -----
-  style        autumn
-  text_editor  default
-  paper        letter
-  ads_token    None
-  ads_display  20
+    Examples
+    --------
+    >>> import bibmanager.config_manager as cm
+    >>> # Show all parameters and values:
+    >>> cm.display()
+    bibmanager configuration file:
+    PARAMETER    VALUE
+    -----------  -----
+    style        autumn
+    text_editor  default
+    paper        letter
+    ads_token    None
+    ads_display  20
 
-  >>> # Show an specific parameter:
-  >>> cm.display('text_editor')
-  text_editor: default
-  """
-  if key is not None:
-      print(f"{key}: {get(key)}")
-  else:
-      config = configparser.ConfigParser()
-      config.read(u.HOME+'config')
-      print("\nbibmanager configuration file:"
-            "\nPARAMETER    VALUE"
-            "\n-----------  -----")
-      for key, value in config['BIBMANAGER'].items():
-          print(f"{key:11}  {value}")
+    >>> # Show an specific parameter:
+    >>> cm.display('text_editor')
+    text_editor: default
+    """
+    if key is not None:
+        print(f"{key}: {get(key)}")
+    else:
+        config = configparser.ConfigParser()
+        config.read(u.HOME+'config')
+        print("\nbibmanager configuration file:"
+              "\nPARAMETER    VALUE"
+              "\n-----------  -----")
+        for key, value in config['BIBMANAGER'].items():
+            print(f"{key:11}  {value}")
 
 
 def get(key):
-  """
-  Get the value of a parameter in the bibmanager config file.
+    """
+    Get the value of a parameter in the bibmanager config file.
 
-  Parameters
-  ----------
-  key: String
-     The requested parameter name.
+    Parameters
+    ----------
+    key: String
+       The requested parameter name.
 
-  Returns
-  -------
-  value: String
-     Value of the requested parameter.
+    Returns
+    -------
+    value: String
+       Value of the requested parameter.
 
-  Examples
-  --------
-  >>> import bibmanager.config_manager as cm
-  >>> cm.get('paper')
-  'letter'
-  >>> cm.get('style')
-  'autumn'
-  """
-  config = configparser.ConfigParser()
-  config.read(u.HOME+'config')
+    Examples
+    --------
+    >>> import bibmanager.config_manager as cm
+    >>> cm.get('paper')
+    'letter'
+    >>> cm.get('style')
+    'autumn'
+    """
+    config = configparser.ConfigParser()
+    config.read(u.HOME+'config')
 
-  if not config.has_option('BIBMANAGER', key):
-      raise ValueError(f"'{key}' is not a valid bibmanager config parameter.\n"
-          f"The available parameters are:\n  {config.options('BIBMANAGER')}")
-  return config.get('BIBMANAGER', key)
+    if not config.has_option('BIBMANAGER', key):
+        raise ValueError(f"'{key}' is not a valid bibmanager config parameter.\n"
+            f"The available parameters are:\n  {config.options('BIBMANAGER')}")
+    return config.get('BIBMANAGER', key)
 
 
 def set(key, value):
-  """
-  Set the value of a bibmanager config parameter.
+    """
+    Set the value of a bibmanager config parameter.
 
-  Parameters
-  ----------
-  key: String
-     bibmanager config parameter to set.
-  value: String
-     Value to set for input parameter.
+    Parameters
+    ----------
+    key: String
+       bibmanager config parameter to set.
+    value: String
+       Value to set for input parameter.
 
-  Examples
-  --------
-  >>> import bibmanager.config_manager as cm
-  >>> # Update text editor:
-  >>> cm.set('text_editor', 'vim')
-  text_editor updated to: vim.
+    Examples
+    --------
+    >>> import bibmanager.config_manager as cm
+    >>> # Update text editor:
+    >>> cm.set('text_editor', 'vim')
+    text_editor updated to: vim.
 
-  >>> # Invalid bibmanager parameter:
-  >>> cm.set('styles', 'arduino')
-  ValueError: 'styles' is not a valid bibmanager config parameter. The available
-  parameters are:  ['style', 'text_editor', 'paper', 'ads_token', 'ads_display']
+    >>> # Invalid bibmanager parameter:
+    >>> cm.set('styles', 'arduino')
+    ValueError: 'styles' is not a valid bibmanager config parameter. The available
+    parameters are:  ['style', 'text_editor', 'paper', 'ads_token', 'ads_display']
 
-  >>> # Attempt to set an invalid style:
-  >>> cm.set('style', 'fake_style')
-  ValueError: 'fake_style' is not a valid style option.  Available options are:
-    default, emacs, friendly, colorful, autumn, murphy, manni, monokai, perldoc,
-    pastie, borland, trac, native, fruity, bw, vim, vs, tango, rrt, xcode, igor,
-    paraiso-light, paraiso-dark, lovelace, algol, algol_nu, arduino,
-    rainbow_dash, abap
+    >>> # Attempt to set an invalid style:
+    >>> cm.set('style', 'fake_style')
+    ValueError: 'fake_style' is not a valid style option.  Available options are:
+      default, emacs, friendly, colorful, autumn, murphy, manni, monokai, perldoc,
+      pastie, borland, trac, native, fruity, bw, vim, vs, tango, rrt, xcode, igor,
+      paraiso-light, paraiso-dark, lovelace, algol, algol_nu, arduino,
+      rainbow_dash, abap
 
-  >>> # Attempt to set an invalid command for text_editor:
-  >>> cm.set('text_editor', 'my_own_editor')
-  ValueError: 'my_own_editor' is not a valid text editor.
+    >>> # Attempt to set an invalid command for text_editor:
+    >>> cm.set('text_editor', 'my_own_editor')
+    ValueError: 'my_own_editor' is not a valid text editor.
 
-  >>> # Beware, one can still set a valid command that doesn't edit text:
-  >>> cm.set('text_editor', 'less')
-  text_editor updated to: less.
-  """
-  config = configparser.ConfigParser()
-  config.read(u.HOME+'config')
-  if not config.has_option('BIBMANAGER', key):
-      # Use gt on invalid key to raise an error:
-      get(key)
+    >>> # Beware, one can still set a valid command that doesn't edit text:
+    >>> cm.set('text_editor', 'less')
+    text_editor updated to: less.
+    """
+    config = configparser.ConfigParser()
+    config.read(u.HOME+'config')
+    if not config.has_option('BIBMANAGER', key):
+        # Use gt on invalid key to raise an error:
+        get(key)
 
-  # Check for exceptions:
-  if key == 'style' and value not in STYLE_MAP.keys():
-      raise ValueError(f"'{value}' is not a valid style option.  "
-                       f"Available options are:\n{styles}")
+    # Check for exceptions:
+    if key == 'style' and value not in STYLE_MAP.keys():
+        raise ValueError(f"'{value}' is not a valid style option.  "
+                         f"Available options are:\n{styles}")
 
-  # The code identifies invalid commands, but cannot assure that a
-  # command actually applies to a text file.
-  if key == 'text_editor' and value!='default' and shutil.which(value) is None:
-      raise ValueError(f"'{value}' is not a valid text editor.")
+    # The code identifies invalid commands, but cannot assure that a
+    # command actually applies to a text file.
+    if key == 'text_editor' and value!='default' and shutil.which(value) is None:
+        raise ValueError(f"'{value}' is not a valid text editor.")
 
-  if key == 'ads_display' and (not value.isnumeric() or value=='0'):
-      raise ValueError(f"The {key} value must be a positive integer.")
+    if key == 'ads_display' and (not value.isnumeric() or value=='0'):
+        raise ValueError(f"The {key} value must be a positive integer.")
 
-  # Set value if there were no exceptions raised:
-  config.set('BIBMANAGER', key, value)
-  with open(u.HOME+'config', 'w') as configfile:
-      config.write(configfile)
-  print(f'{key} updated to: {value}.')
+    # Set value if there were no exceptions raised:
+    config.set('BIBMANAGER', key, value)
+    with open(u.HOME+'config', 'w') as configfile:
+        config.write(configfile)
+    print(f'{key} updated to: {value}.')
 
 
 def update_keys():
-  """Update config in HOME with keys from ROOT, without overwriting values."""
-  config_root = configparser.ConfigParser()
-  config_root.read(u.ROOT+'config')
-  # Wont complain if HOME+'config' does not exist (keep ROOT values):
-  config_root.read(u.HOME+'config')
-  with open(u.HOME+'config', 'w') as configfile:
-      config_root.write(configfile)
+    """Update config in HOME with keys from ROOT, without overwriting values."""
+    config_root = configparser.ConfigParser()
+    config_root.read(u.ROOT+'config')
+    # Wont complain if HOME+'config' does not exist (keep ROOT values):
+    config_root.read(u.HOME+'config')
+    with open(u.HOME+'config', 'w') as configfile:
+        config_root.write(configfile)


### PR DESCRIPTION
This PR fixes the indentation in all Python scripts (where functions used an indentation of 2 spaces instead of the normal 4).
It also adds the possibility to recognize months given as a digit instead of a 3-letter string.