### PR TITLE
Tags

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,18 @@
 language: python
+os: linux
+dist: focal
 
-matrix:
+jobs:
   include:
   - python: 3.6
   - python: 3.7
-    sudo: required
-    dist: xenial
+  - python: 3.8
+  - python: 3.9
 
 install:
   - pip install -r requirements.txt
   - pip install requests-mock
   - pip install -e .
+
 script:
   - pytest tests -v

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -2510,3 +2510,7 @@ Updated tests for many user-input cases for this cli.
 Fixed screen output when cli_ads_add()'s input prompt is blank.
 Added test.
 
+*****
+
+Some PEP8ing.
+

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -2505,3 +2505,8 @@ Updated tests and docstrings.
 Updated cli_ads_add() to enable passing tags to the entries.
 Updated tests for many user-input cases for this cli.
 
+*****
+
+Fixed screen output when cli_ads_add()'s input prompt is blank.
+Added test.
+

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -2543,3 +2543,10 @@ Changed verb argument user-interface for bibm search command,
 now it requires an interger value (thus enabling negative values).
 Updated docs and tests.
 
+
+*****  Sun Dec 5 17:33:57 CET 2021  *****
+
+Implemented u.tokenizer() function to fast-track formatted-text
+tuples for attribute:value pairs.
+Documented and tested.
+

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -2458,3 +2458,10 @@ Some documentation is TBD.
 Updated bm.search() to include searches by tag.
 Testing is TBD.
 
+*****
+
+Implemented u.DynamicKeywordCompleter()
+and u.DynamicKeywordCompleter() to improve and replace on the
+auto completer searches, providing tab-completion options after keys
+which can be colon-ended or double quote-ended.
+

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -2520,3 +2520,8 @@ Some PEP8ing.
 Updated docs adding the tag directive
 and updating the index and the ads-add directive.
 
+*****
+
+Improved syntax in am.add_bibtex().
+(No actual change in behavior)
+

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -2488,3 +2488,9 @@ In the browser, hide the info_bar when searching for tags,
 (such that the search bar is at the bottom and the tab completions
 are always displayed above it).
 
+*****
+
+Fixed search word completions (display only on-screen entries).
+This commit should complete the new browser tag capabilities
+proposed in #75 (only bibm ads-add tagging left to update)
+

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -2465,9 +2465,19 @@ and u.DynamicKeywordCompleter() to improve and replace on the
 auto completer searches, providing tab-completion options after keys
 which can be colon-ended or double quote-ended.
 
+
 *****  Mon Sep 27 11:30:13 -03 2021  *****
 
 Completely refactored cli_search() function in __main__.py
 enabling searches by tag and upgrading the completers.
 Removed u.search_keys, no longer used.
+
+
+*****  Tue Nov 30 23:56:37 CET 2021  *****
+
+Enabled searches by tag in the browser.
+The 't' keybinding launches the tag-search prompt, after the user
+input, the main text will display only the entries containing the
+requested tag(s).  If there is not matching entries, display all
+entries of the database.
 

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -2532,3 +2532,8 @@ Implemented bm.display_list() to display a list of BibTeX entries
 with different verbosity levels.
 Documented and tested.
 
+*****
+
+Enabled possibility to display entries with given tags from cli.
+Modified cli_search() and cli_tag() to use bm.display_list().
+

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -2494,3 +2494,9 @@ Fixed search word completions (display only on-screen entries).
 This commit should complete the new browser tag capabilities
 proposed in #75 (only bibm ads-add tagging left to update)
 
+
+*****  Sat Dec 4 01:36:03 CET 2021  *****
+
+Updated am.add_bibtex() to include optional tags.
+Updated tests and docstrings.
+

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -2514,3 +2514,9 @@ Added test.
 
 Some PEP8ing.
 
+
+*****  Sat Dec 4 13:08:59 CET 2021  *****
+
+Updated docs adding the tag directive
+and updating the index and the ads-add directive.
+

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -2566,3 +2566,8 @@ Updated tests.
 
 Updated api.rst docs.
 
+*****
+
+Bumped bibmanager to version 1.4.0
+When merged, this commit solves #75
+

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -2415,3 +2415,9 @@ in text mode.
 
 Bumped bibmanager to version 1.3.6
 
+
+*****  So 15. Aug 18:36:33 CEST 2021  *****
+
+Added tag meta property to Bib() objects.
+Tests are TBD.
+

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -2550,3 +2550,9 @@ Implemented u.tokenizer() function to fast-track formatted-text
 tuples for attribute:value pairs.
 Documented and tested.
 
+*****
+
+Refactored bm.display_list() to display formatted text
+rather than plain text.
+Updated tests.
+

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -2500,3 +2500,8 @@ proposed in #75 (only bibm ads-add tagging left to update)
 Updated am.add_bibtex() to include optional tags.
 Updated tests and docstrings.
 
+*****
+
+Updated cli_ads_add() to enable passing tags to the entries.
+Updated tests for many user-input cases for this cli.
+

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -2537,3 +2537,9 @@ Documented and tested.
 Enabled possibility to display entries with given tags from cli.
 Modified cli_search() and cli_tag() to use bm.display_list().
 
+*****
+
+Changed verb argument user-interface for bibm search command,
+now it requires an interger value (thus enabling negative values).
+Updated docs and tests.
+

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -2577,3 +2577,7 @@ Added mock_init inpo tests that require the 'style' config param
 Avoiding Travis error:
 ValueError: 'style' is not a valid bibmanager config parameter.
 
+*****
+
+Updated travis.yml file to include python versions 3.6 to 3.9
+

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -2465,3 +2465,9 @@ and u.DynamicKeywordCompleter() to improve and replace on the
 auto completer searches, providing tab-completion options after keys
 which can be colon-ended or double quote-ended.
 
+*****  Mon Sep 27 11:30:13 -03 2021  *****
+
+Completely refactored cli_search() function in __main__.py
+enabling searches by tag and upgrading the completers.
+Removed u.search_keys, no longer used.
+

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -2571,3 +2571,9 @@ Updated api.rst docs.
 Bumped bibmanager to version 1.4.0
 When merged, this commit solves #75
 
+*****
+
+Added mock_init inpo tests that require the 'style' config param
+Avoiding Travis error:
+ValueError: 'style' is not a valid bibmanager config parameter.
+

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -2556,3 +2556,9 @@ Refactored bm.display_list() to display formatted text
 rather than plain text.
 Updated tests.
 
+*****
+
+Refactored am.display() to display formatted text
+rather than plain text.
+Updated tests.
+

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -2421,3 +2421,12 @@ Bumped bibmanager to version 1.3.6
 Added tag meta property to Bib() objects.
 Tests are TBD.
 
+
+*****  Sat Sep 11 20:38:17 -03 2021  *****
+
+Refactored get_current_key() to search entry boundaries by blanks
+instead of by the at character.
+Refactored browser expand's command to always include blank lines
+around expanded entries. Remove the blanks when collapsing (and
+leaving keys next to each other).
+

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -2446,3 +2446,8 @@ Added BM_HISTORY_TAGS constant to keep history of tag searches.
 
 Changed default tags value from None to [].
 
+*****
+
+Implemented cli_tag() and prompt_search_tags() to enable
+adding/removing tags from the command line.
+Some documentation is TBD.

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -2434,3 +2434,11 @@ leaving keys next to each other).
 
 Added meta content into expanded entries (shown above) content.
 
+
+*****  Fri Sep 17 17:38:21 -03 2021  *****
+
+Added LastKeyCompleter and LastKeySuggestCompleter to implement
+a dynamic autocomplete according to the latest key found in the
+input text.
+Added BM_HISTORY_TAGS constant to keep history of tag searches.
+

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -2451,3 +2451,10 @@ Changed default tags value from None to [].
 Implemented cli_tag() and prompt_search_tags() to enable
 adding/removing tags from the command line.
 Some documentation is TBD.
+
+
+*****  Fri Sep 24 22:03:53 -03 2021  *****
+
+Updated bm.search() to include searches by tag.
+Testing is TBD.
+

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -2562,3 +2562,7 @@ Refactored am.display() to display formatted text
 rather than plain text.
 Updated tests.
 
+*****
+
+Updated api.rst docs.
+

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -2481,3 +2481,10 @@ input, the main text will display only the entries containing the
 requested tag(s).  If there is not matching entries, display all
 entries of the database.
 
+
+*****  Wed Dec 1 21:43:53 CET 2021  *****
+
+In the browser, hide the info_bar when searching for tags,
+(such that the search bar is at the bottom and the tab completions
+are always displayed above it).
+

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -2525,3 +2525,10 @@ and updating the index and the ads-add directive.
 Improved syntax in am.add_bibtex().
 (No actual change in behavior)
 
+
+*****  Sat Dec 4 19:58:34 CET 2021  *****
+
+Implemented bm.display_list() to display a list of BibTeX entries
+with different verbosity levels.
+Documented and tested.
+

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -2442,3 +2442,7 @@ a dynamic autocomplete according to the latest key found in the
 input text.
 Added BM_HISTORY_TAGS constant to keep history of tag searches.
 
+*****
+
+Changed default tags value from None to [].
+

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -2430,3 +2430,7 @@ Refactored browser expand's command to always include blank lines
 around expanded entries. Remove the blanks when collapsing (and
 leaving keys next to each other).
 
+*****
+
+Added meta content into expanded entries (shown above) content.
+

--- a/bibmanager/VERSION.py
+++ b/bibmanager/VERSION.py
@@ -2,4 +2,4 @@
 # bibmanager is open-source software under the MIT license (see LICENSE).
 
 # bibmanager Version:
-__version__ = "1.3.6"
+__version__ = "1.4.0"

--- a/bibmanager/__main__.py
+++ b/bibmanager/__main__.py
@@ -5,7 +5,6 @@ import argparse
 import itertools
 import os
 import re
-import textwrap
 from datetime import date
 from packaging import version
 

--- a/bibmanager/__main__.py
+++ b/bibmanager/__main__.py
@@ -366,31 +366,39 @@ def cli_ads_add(args):
     """Command-line interface for ads-add call."""
     if args.bibcode is None and args.key is None:
         inputs = prompt_toolkit.prompt(
-            "Enter pairs of ADS bibcodes and BibTeX keys, one pair per line\n"
-            "separated by blanks (press META+ENTER or ESCAPE ENTER when "
-            "done):\n", multiline=True)
-        bibcodes, keys = [], []
+            "Enter pairs of ADS bibcodes and BibTeX keys (plus optional tags)\n"
+            "Use one line for each BibTeX entry, separate fields with blank "
+            "spaces.\n(press META+ENTER or ESCAPE ENTER when done):\n",
+            multiline=True)
+
+        bibcodes, keys, tags_list = [], [], []
         inputs = inputs.strip().split('\n')
         for line in inputs:
             if len(line.split()) == 0:
                 continue
-            elif len(line.split()) != 2:
-                print("\nError: Invalid syntax, each line must have two strings"
-                      " specifying a bibcode\n and key, separated by a blank.")
+            elif len(line.split()) == 1:
+                print(
+                    "\nInvalid syntax, each line must have at least two "
+                    "strings specifying\na bibcode, a key, and optional tags; "
+                    "separated by blank spaces.")
                 return
-            bibcode, key = line.split()
+            items = line.split()
+            bibcode, key = items[0:2]
+            tags = items[2:]
             bibcodes.append(bibcode)
             keys.append(key)
+            tags_list.append(tags)
 
     elif args.bibcode is not None and args.key is not None:
         bibcodes = [args.bibcode]
-        keys     = [args.key]
+        keys = [args.key]
+        tags_list = [args.tags]
     else:
         print("\nError: Invalid input, 'bibm ads-add' expects either zero or "
               "two arguments.")
         return
     try:
-        am.add_bibtex(bibcodes, keys)
+        am.add_bibtex(bibcodes, keys, tags=tags_list)
     except ValueError as e:
         print(f"\nError: {str(e)}")
 
@@ -1074,12 +1082,14 @@ Examples
   # Add the entry to the bibmanager database:
   bibm ads-add 1925PhDT.........1P Payne1925phdStellarAtmospheres"""
     ads_add = sp.add_parser('ads-add', description=ads_add_description,
-        usage="bibm ads-add [-h] [-f] [-o] [bibcode key]",
+        usage="bibm ads-add [-h] [-f] [-o] [bibcode key] [tag1 [tag2 ...]]",
         formatter_class=argparse.RawDescriptionHelpFormatter)
     ads_add.add_argument('bibcode', action='store', nargs='?',
         help='The ADS bibcode of an entry.')
     ads_add.add_argument('key', action='store', nargs='?',
         help='BibTeX key to assign to the entry.')
+    ads_add.add_argument('tags', action='store', nargs='*',
+        help='BibTeX tags to assign to the entry.')
     ads_add.add_argument('-f', '--fetch', action='store_true', default=False,
         help="Fetch the PDF of the added entries.")
     ads_add.add_argument('-o', '--open', action='store_true', default=False,

--- a/bibmanager/__main__.py
+++ b/bibmanager/__main__.py
@@ -370,6 +370,9 @@ def cli_ads_add(args):
             "Use one line for each BibTeX entry, separate fields with blank "
             "spaces.\n(press META+ENTER or ESCAPE ENTER when done):\n",
             multiline=True)
+        # Empty input:
+        if inputs.strip() == '':
+            return
 
         bibcodes, keys, tags_list = [], [], []
         inputs = inputs.strip().split('\n')

--- a/bibmanager/__main__.py
+++ b/bibmanager/__main__.py
@@ -204,6 +204,12 @@ def cli_search(args):
         return
 
     matches = bm.search(authors, years, title_kw, key, bibcode, tags)
+    # Catch case when user sets '-v' without arguments:
+    if args.verb is None:
+        print(
+            'Deprecation warning:\n'
+            'The verbosity argument must be set to an integer value')
+        args.verb = 1
     bm.display_list(matches, args.verb)
 
 
@@ -728,7 +734,8 @@ Description
   whereas multiple-key queries and multiple-bibcode queries act with OR
   logic (see examples below).
 
-  There are four levels of verbosity:
+  There are five levels of verbosity:
+  verb < 0:  Display only the keys of the entries
   verb = 0:  Display the title, year, first author, and key
   verb = 1:  Display additionally the ADS/arXiv urls and meta info
   verb = 2:  Display additionally the full list of authors
@@ -782,22 +789,29 @@ Examples
   bibm search
   bibcode:1917PASP...29..206C bibcode:1918ApJ....48..154S
 
-  # Use '-v' argument to set the verbosity, for example:
-  # Display title, year, first author, and all keys/urls:
-  bibm search -v
+  # Use the '-v VERB' argument to set the verbosity, for example:
+  # Display only the keys:
+  bibm search -v -1
+  year: 1910-1920
+
+  # Display title, year, author list, and URLs and meta info:
+  bibm search -v 2
   author:"Burbidge, E"
-  # Display title, year, author list, and all keys/urls:
-  bibm search -vv
-  author:"Burbidge, E"
+
   # Display full BibTeX entries:
-  bibm search -vvv
+  bibm search -v 3
   author:"Burbidge, E"
 """
-    search = sp.add_parser('search', description=search_description,
-        usage="bibm search [-h] [-v]",
+    search = sp.add_parser(
+        'search',
+        description=search_description,
+        usage="bibm search [-h] [-v VERB]",
         formatter_class=argparse.RawDescriptionHelpFormatter)
-    search.add_argument('-v', '--verb', action='count', default=0,
-        help='Set output verbosity.')
+    search.add_argument(
+        '-v', '--verb', action='store', nargs='?', default=0, type=int,
+        help='Verbosity level if used to display entries.')
+    # TBD: By 01/12/2022 change nargs to 1 (leave it for a moment since
+    # I'm changing the user interface)
     search.set_defaults(func=cli_search)
 
 
@@ -805,18 +819,21 @@ Examples
 {u.BOLD}Browse through the bibmanager database.{u.END}
 
 Description
-  Display the entire bibmanager database into a full-screen application
-  that lets you:
+  Display the entire bibmanager database in an interactive
+  full-screen application that lets you:
   - Navigate through or search for specific entries
   - Visualize the entries' full BibTeX content
   - Select entries for printing to screen or to file
   - Open the entries' PDF files
   - Open the entries in ADS through the web browser
+  - Select sub-group of entries by tags
 
 Examples
   bibm browse
 """
-    browse = sp.add_parser('browse', description=browse_description,
+    browse = sp.add_parser(
+        'browse',
+        description=browse_description,
         formatter_class=argparse.RawDescriptionHelpFormatter)
     browse.set_defaults(func=cli_browse)
 

--- a/bibmanager/__main__.py
+++ b/bibmanager/__main__.py
@@ -204,30 +204,7 @@ def cli_search(args):
         return
 
     matches = bm.search(authors, years, title_kw, key, bibcode, tags)
-
-    # Display outputs depending on the verb level:
-    if args.verb >= 3:
-        bm.display_bibs(labels=None, bibs=matches, meta=True)
-        return
-
-    for match in matches:
-        year = '' if match.year is None else f', {match.year}'
-        title = textwrap.fill(
-            f"Title: {match.title}{year}",
-            width=78, subsequent_indent='       ')
-        author_format = 'short' if args.verb < 2 else 'long'
-        authors = textwrap.fill(
-            f"Authors: {match.get_authors(format=author_format)}",
-            width=78, subsequent_indent='         ')
-        keys = f"\nkey: {match.key}"
-        if args.verb > 0 and match.pdf is not None:
-            keys = f"\nPDF file:  {match.pdf}{keys}"
-        if args.verb > 0 and match.eprint is not None:
-            keys = f"\narXiv url: http://arxiv.org/abs/{match.eprint}{keys}"
-        if args.verb > 0 and match.adsurl is not None:
-            keys = f"\nADS url:   {match.adsurl}{keys}"
-            keys = f"\nbibcode:   {match.bibcode}{keys}"
-        print(f"\n{title}\n{authors}{keys}")
+    bm.display_list(matches, args.verb)
 
 
 def cli_tag(args):
@@ -243,7 +220,8 @@ def cli_tag(args):
 
     # Show entries with selected tags:
     if len(keys) == 0:
-        # TBD
+        matches = bm.search(tags=tags)
+        bm.display_list(matches, args.verb)
         return
 
     # Add or delete tags from entries:
@@ -699,6 +677,15 @@ Description
   searches.  The tags are case sensitive and should not contain blank
   spaces.
 
+  Additionally, if the user only sets tags (but no entries), this
+  command will display the existing entries that contain those tags.
+  There are five levels of verbosity:
+  verb < 0:  Display only the keys of the entries
+  verb = 0:  Display the title, year, first author, and key
+  verb = 1:  Display additionally the ADS/arXiv urls and meta info
+  verb = 2:  Display additionally the full list of authors
+  verb > 2:  Display the full BibTeX entries
+
 Examples
   # Add a tag to an entry:
   bibm tag
@@ -721,6 +708,9 @@ Examples
     tag.add_argument(
         '-d', '--delete', action='store_true', default=False,
         help="Delete tags instead of add.")
+    tag.add_argument(
+        '-v', '--verb', action='store', nargs=1, default=0, type=int,
+        help='Verbosity level if used to display entries.')
     tag.set_defaults(func=cli_tag)
 
 
@@ -738,11 +728,11 @@ Description
   whereas multiple-key queries and multiple-bibcode queries act with OR
   logic (see examples below).
 
-  There are four levels of verbosity (see examples below):
-  - zero shows the title, year, first author, and key;
-  - one adds the ADS and arXiv urls;
-  - two adds the full list of authors;
-  - and three displays the full BibTeX entry.
+  There are four levels of verbosity:
+  verb = 0:  Display the title, year, first author, and key
+  verb = 1:  Display additionally the ADS/arXiv urls and meta info
+  verb = 2:  Display additionally the full list of authors
+  verb > 2:  Display the full BibTeX entries
 
 Notes
   (1) There's no need to worry about case in author names, unless they
@@ -792,14 +782,14 @@ Examples
   bibm search
   bibcode:1917PASP...29..206C bibcode:1918ApJ....48..154S
 
-  # Use '-v' argument to increase verbosity, for example:
+  # Use '-v' argument to set the verbosity, for example:
   # Display title, year, first author, and all keys/urls:
   bibm search -v
   author:"Burbidge, E"
   # Display title, year, author list, and all keys/urls:
   bibm search -vv
   author:"Burbidge, E"
-  # Display full BibTeX entry:
+  # Display full BibTeX entries:
   bibm search -vvv
   author:"Burbidge, E"
 """

--- a/bibmanager/ads_manager/ads_manager.py
+++ b/bibmanager/ads_manager/ads_manager.py
@@ -18,7 +18,7 @@ import pickle
 
 import requests
 
-from .. import bib_manager    as bm
+from .. import bib_manager as bm
 from .. import config_manager as cm
 from .. import utils as u
 
@@ -194,7 +194,7 @@ def display(results, start, index, rows, nmatch, short=True):
 
 
 def add_bibtex(input_bibcodes, input_keys, eprints=[], dois=[],
-               update_keys=True, base=None):
+               update_keys=True, base=None, tags=None):
     """
     Add bibtex entries from a list of ADS bibcodes, with specified keys.
     New entries will replace old ones without asking if they are
@@ -216,6 +216,8 @@ def add_bibtex(input_bibcodes, input_keys, eprints=[], dois=[],
     base: List of Bib() objects
         If None, merge new entries into the bibmanager database.
         If not None, merge new entries into base.
+    tags: Nested list of strings
+        The list of tags for each input bibcode.
 
     Returns
     -------
@@ -246,6 +248,9 @@ def add_bibtex(input_bibcodes, input_keys, eprints=[], dois=[],
     token = cm.get('ads_token')
     # Keep the originals untouched (copies will be modified):
     bibcodes, keys = input_bibcodes.copy(), input_keys.copy()
+
+    if tags is None:
+        tags = [[] for _ in bibcodes]
 
     # Make request:
     size = 2000
@@ -301,7 +306,6 @@ def add_bibtex(input_bibcodes, input_keys, eprints=[], dois=[],
         # Output bibcode is input bibcode:
         if rkey in bibcodes:
             ibib = bibcodes.index(rkey)
-            new_key = keys[ibib]
         # Else, check for bibcode updates in remaining bibcodes:
         elif eprint is not None and eprint in eprints:
             ibib = eprints.index(eprint)
@@ -309,6 +313,7 @@ def add_bibtex(input_bibcodes, input_keys, eprints=[], dois=[],
             ibib = dois.index(doi)
 
         if ibib is not None:
+            new.tags = tags[ibib]
             new_key = keys[ibib]
             updated_key = key_update(new_key, rkey, bibcodes[ibib])
             if update_keys and updated_key.lower() != new_key.lower():

--- a/bibmanager/ads_manager/ads_manager.py
+++ b/bibmanager/ads_manager/ads_manager.py
@@ -300,22 +300,19 @@ def add_bibtex(input_bibcodes, input_keys, eprints=[], dois=[],
     for result in reversed(results):
         ibib = None
         new = bm.Bib(result)
-        rkey = new.key
-        doi = new.doi
-        eprint = new.eprint
-        # Output bibcode is input bibcode:
-        if rkey in bibcodes:
-            ibib = bibcodes.index(rkey)
+        # Output bibcode is one of the input bibcodes:
+        if new.bibcode in bibcodes:
+            ibib = bibcodes.index(new.bibcode)
         # Else, check for bibcode updates in remaining bibcodes:
-        elif eprint is not None and eprint in eprints:
-            ibib = eprints.index(eprint)
-        elif doi is not None and doi in dois:
-            ibib = dois.index(doi)
+        elif new.eprint is not None and new.eprint in eprints:
+            ibib = eprints.index(new.eprint)
+        elif new.doi is not None and new.doi in dois:
+            ibib = dois.index(new.doi)
 
         if ibib is not None:
             new.tags = tags[ibib]
             new_key = keys[ibib]
-            updated_key = key_update(new_key, rkey, bibcodes[ibib])
+            updated_key = key_update(new_key, new.bibcode, bibcodes[ibib])
             if update_keys and updated_key.lower() != new_key.lower():
                 new_key = updated_key
                 new_keys.append([keys[ibib], new_key])

--- a/bibmanager/bib_manager/bib_manager.py
+++ b/bibmanager/bib_manager/bib_manager.py
@@ -56,7 +56,7 @@ class Bib(object):
   """
   Bibliographic-entry object.
   """
-  def __init__(self, entry, pdf=None, freeze=None, tags=None):
+  def __init__(self, entry, pdf=None, freeze=None, tags=[]):
       """
       Create a Bib() object from given entry.
 
@@ -202,7 +202,7 @@ class Bib(object):
           meta += 'freeze\n'
       if self.pdf is not None:
           meta += f'pdf: {self.pdf}\n'
-      if self.tags is not None:
+      if self.tags != []:
           meta += 'tags: ' + ' '.join(tag for tag in self.tags) + '\n'
       return meta
 
@@ -602,14 +602,14 @@ def read_file(bibfile=None, text=None):
         meta = {
             'freeze': None,
             'pdf': None,
-            'tags': None,
+            'tags': [],
         }
         for line in text[position:start_pos].splitlines():
             if line.lower().startswith('pdf'):
                 meta['pdf'] = line.split()[-1]
             if line.lower().strip() == 'freeze':
                 meta['freeze'] = True
-            if line.lower().startswith('tags'):
+            if line.lower().startswith('tags: '):
                 meta['tags'] = line.split()[1:]
 
         entries.append(text[start_pos:end_pos+1])
@@ -1174,8 +1174,8 @@ def prompt_search(keywords, field, prompt_text):
     fetch_keywords = [f'{keyword}:' for keyword in keywords]
     completer = u.KeyPathCompleter(fetch_keywords, bibs)
     suggester = u.AutoSuggestKeyCompleter()
-    validator = u.AlwaysPassValidator(bibs,
-        toolbar_text=f"(Press 'tab' for autocomplete)")
+    validator = u.AlwaysPassValidator(
+        bibs, toolbar_text=f"(Press 'tab' for autocomplete)")
 
     session = prompt_toolkit.PromptSession(
         history=FileHistory(u.BM_HISTORY_PDF()))

--- a/bibmanager/bib_manager/bib_manager.py
+++ b/bibmanager/bib_manager/bib_manager.py
@@ -1020,7 +1020,8 @@ def edit():
     merge(new=new)
 
 
-def search(authors=None, year=None, title=None, key=None, bibcode=None):
+def search(authors=None, year=None, title=None, key=None, bibcode=None,
+        tags=None):
     """
     Search in bibmanager database by authors, year, or title keywords.
 
@@ -1039,6 +1040,8 @@ def search(authors=None, year=None, title=None, key=None, bibcode=None):
         Match any entry whose key is in the input key.
     bibcode: String or list of strings
         Match any entry whose bibcode is in the input bibcode.
+    tags: String or list of strings
+        Match entries containing all specified tags.
 
     Returns
     -------
@@ -1077,13 +1080,14 @@ def search(authors=None, year=None, title=None, key=None, bibcode=None):
             matches = [
                 bib for bib in matches
                 if bib.year is not None
-                if bib.year >= year[0]
+                if year[0] <= bib.year <= year[1]
             ]
-            matches = [
-                bib for bib in matches
-                if bib.year is not None
-                if bib.year <= year[1]
-            ]
+
+    if tags is not None:
+        if isinstance(tags, str):
+            tags = [tags]
+        for tag in tags:
+            matches = [bib for bib in matches if tag in bib.tags]
 
     if authors is not None:
         if isinstance(authors, str):

--- a/bibmanager/bib_manager/bib_manager.py
+++ b/bibmanager/bib_manager/bib_manager.py
@@ -446,7 +446,7 @@ def display_list(bibs, verb=-1):
 
     if verb < 0:
         keys = "\n".join([bib.key for bib in bibs])
-        print(f'Keys:\n{keys}')
+        print(f'\nKeys:\n{keys}')
         return
 
     for bib in bibs:

--- a/bibmanager/bib_manager/bib_manager.py
+++ b/bibmanager/bib_manager/bib_manager.py
@@ -56,7 +56,7 @@ class Bib(object):
   """
   Bibliographic-entry object.
   """
-  def __init__(self, entry, pdf=None, freeze=None):
+  def __init__(self, entry, pdf=None, freeze=None, tags=None):
       """
       Create a Bib() object from given entry.
 
@@ -104,6 +104,7 @@ class Bib(object):
       # Meta info (not contained in bibtex):
       self.pdf = pdf
       self.freeze = freeze
+      self.tags = tags
 
       fields = u.get_fields(self.content)
       self.key = next(fields)
@@ -184,7 +185,7 @@ class Bib(object):
   def update_content(self, other):
       """Update the bibtex content of self with that of other."""
       # Update these (non-bibtex info) only if not None:
-      non_bibtex = ['pdf', 'freeze']
+      non_bibtex = ['pdf', 'freeze', 'tags']
       for key,val in other.__dict__.items():
           if key in self.__dict__ and not (key in non_bibtex and val is None):
               setattr(self, key, val)
@@ -201,6 +202,8 @@ class Bib(object):
           meta += 'freeze\n'
       if self.pdf is not None:
           meta += f'pdf: {self.pdf}\n'
+      if self.tags is not None:
+          meta += 'tags: ' + ' '.join(tag for tag in self.tags) + '\n'
       return meta
 
   def __repr__(self):
@@ -597,14 +600,17 @@ def read_file(bibfile=None, text=None):
             continue
         # Content outside/before entry is comments or meta info:
         meta = {
-            'pdf': None,
             'freeze': None,
+            'pdf': None,
+            'tags': None,
         }
         for line in text[position:start_pos].splitlines():
             if line.lower().startswith('pdf'):
                 meta['pdf'] = line.split()[-1]
             if line.lower().strip() == 'freeze':
                 meta['freeze'] = True
+            if line.lower().startswith('tags'):
+                meta['tags'] = line.split()[1:]
 
         entries.append(text[start_pos:end_pos+1])
         meta_info.append(meta)

--- a/bibmanager/bib_manager/browser.py
+++ b/bibmanager/bib_manager/browser.py
@@ -253,7 +253,7 @@ def browse():
     bibs = bm.load()
     keys = [bib.key for bib in bibs]
     compact_text = "\n".join(keys)
-    expanded_text = "\n\n".join(bib.content for bib in bibs)
+    expanded_text = "\n\n".join(bib.meta() + bib.content for bib in bibs)
     # A list object, since I want this to be a global variable
     selected_content = [None]
 
@@ -491,7 +491,7 @@ def browse():
                 start_end[1] += 1
             event.app.clipboard.set_text(bib.key)
         else:
-            expanded_content = bib.content
+            expanded_content = bib.meta() + bib.content
             row = doc.cursor_position_row
             # Add blank lines around if surrounded by keys:
             if row > 0 and doc.lines[row-1] != '':

--- a/bibmanager/bib_manager/browser.py
+++ b/bibmanager/bib_manager/browser.py
@@ -6,14 +6,13 @@ __all__ = [
 ]
 
 from asyncio import Future, ensure_future
-import itertools
-import io
 from contextlib import redirect_stdout
+import io
+import itertools
 import os
 import re
 import textwrap
 import webbrowser
-
 
 from prompt_toolkit import print_formatted_text, search
 from prompt_toolkit.application import Application
@@ -204,9 +203,9 @@ class HighlightEntryProcessor(Processor):
                 for i in range(match.start(), match.end()):
                     old_fragment, text, *_ = fragments[i]
                     fragments[i] = (
-                            old_fragment + self.match_fragment,
-                            fragments[i][1],
-                        )
+                        old_fragment + self.match_fragment,
+                        fragments[i][1],
+                    )
 
         return Transformation(fragments)
 
@@ -317,7 +316,6 @@ def browse():
         ignore_case=False)
 
     # Tag searcher:
-    # TBD: How to force showing tab-completions above?
     tags = sorted(set(itertools.chain(
         *[bib.tags for bib in bibs if bib.tags is not None])))
     tag_buffer = Buffer(
@@ -373,19 +371,22 @@ def browse():
         height=1,
     )
 
-    info_bar = Window(
-        content=FormattedTextControl(get_infobar_text),
-        height=D.exact(1),
-        style="class:status",
-        )
+    info_bar = ConditionalContainer(
+        content=Window(
+            content=FormattedTextControl(get_infobar_text),
+            height=D.exact(1),
+            style="class:status",
+        ),
+        filter=~tag_focus,
+    )
 
     body = HSplit([
         menu_bar,
         text_field,
-        tag_container,
         search_field,
+        tag_container,
         info_bar,
-        ])
+    ])
 
     root_container = FloatContainer(
         content=body,
@@ -620,8 +621,6 @@ def browse():
 
         if has_pdf and not is_missing:
             pm.open(key=key)
-            #except Exception as e:
-            #    show_message("Message", textwrap.fill(str(e), width=70))
             return
 
         if has_pdf and is_missing and not has_bibcode:

--- a/bibmanager/bib_manager/browser.py
+++ b/bibmanager/bib_manager/browser.py
@@ -528,10 +528,12 @@ def browse():
         if len(matches) == 0:
             text_field.compact_text = all_compact_text[:]
             text_field.expanded_text = all_expanded_text[:]
+            search_buffer.completer.words = keys
         else:
             text_field.compact_text = "\n".join([bib.key for bib in matches])
             text_field.expanded_text = "\n\n".join(
                 bib.meta() + bib.content for bib in matches)
+            search_buffer.completer.words = [bib.key for bib in matches]
 
         # Return focus to main text:
         event.app.layout.focus(text_field.window)
@@ -546,6 +548,7 @@ def browse():
     def _deselect_tags(event):
         text_field.compact_text = all_compact_text[:]
         text_field.expanded_text = all_expanded_text[:]
+        search_buffer.completer.words = keys
         # Update main text:
         buffer = event.current_buffer
         text_field.text = text_field.compact_text

--- a/bibmanager/utils/utils.py
+++ b/bibmanager/utils/utils.py
@@ -42,6 +42,7 @@ __all__ = [
     'get_fields',
     'req_input',
     'warnings_format',
+    'tokenizer',
     # Classes:
     'DynamicKeywordCompleter',
     'DynamicKeywordSuggester',
@@ -64,6 +65,7 @@ import numpy as np
 from prompt_toolkit.auto_suggest import AutoSuggest, Suggestion
 from prompt_toolkit.completion import WordCompleter, PathCompleter, Completion
 from prompt_toolkit.validation import Validator
+from pygments.token import Token
 
 from .. import config_manager as cm
 
@@ -1006,6 +1008,63 @@ def req_input(prompt, options):
 def warnings_format(message, category, filename, lineno, file=None, line=None):
     """Custom format for warnings."""
     return f'Warning: {message}\n'
+
+
+def tokenizer(attribute, value, value_token=Token.Literal.String):
+    """
+    Shortcut to generate formatted-text tokens for attribute-value texts.
+
+    The attribute is set in a Token.Name.Attribute style, followed
+    by a colon (Token.Punctuation style), and followed by the value
+    (in value_token style).
+
+    Parameters
+    ----------
+    attribute: String
+        Name of the attribute.
+    value: String
+        The attribute's value.
+    value_token: a pygments.token object
+        The style for the attribute's value.
+
+    Returns
+    -------
+    tokens: List of (style, text) tuples.
+        Tuples that can lated be fed into a FormattedText() or
+        other prompt_toolkit text formatting calls.
+
+    Examples
+    --------
+    >>> import bibmanager.utils as u
+
+    >>> tokens = u.tokenizer('Title', 'Synthesis of the Elements in Stars')
+    >>> print(tokens)
+    [(Token.Name.Attribute, 'Title'),
+     (Token.Punctuation, ': '),
+     (Token.Literal.String, 'Synthesis of the Elements in Stars'),
+     (Token.Text, '\n')]
+
+    >>> # Pretty printing:
+    >>> import prompt_toolkit
+    >>> from prompt_toolkit.formatted_text import PygmentsTokens
+    >>> from pygments.styles import get_style_by_name
+
+    >>> style = prompt_toolkit.styles.style_from_pygments_cls(
+    >>>     get_style_by_name('autumn'))
+    >>> prompt_toolkit.print_formatted_text(
+    >>>     PygmentsTokens(tokens), style=style)
+    Title: Synthesis of the Elements in Stars
+    """
+    if value is None or value == '':
+        return []
+
+    tokens = [
+        (Token.Name.Attribute, attribute),
+        (Token.Punctuation, ': '),
+        (value_token, value),
+        (Token.Text, '\n'),
+    ]
+    return tokens
 
 
 class AutoSuggestCompleter(AutoSuggest):

--- a/bibmanager/utils/utils.py
+++ b/bibmanager/utils/utils.py
@@ -8,7 +8,6 @@ __all__ = [
     'BOLD',
     'END',
     'BANNER',
-    'search_keywords',
     'ads_keywords',
     # Pseudo-constants:
     'BM_DATABASE',
@@ -122,18 +121,6 @@ def BM_PDF():
 # Named tuples:
 Author = namedtuple("Author", "last first von jr")
 Sort_author = namedtuple("Sort_author", "last first von jr year month")
-
-
-# Completer keywords:
-search_keywords = [
-    'author:"^"',
-    'author:""',
-    'year:',
-    'title:""',
-    'tags:',
-    'key:',
-    'bibcode:',
-    ]
 
 # For more info, see  https://adsabs.github.io/help/search/search-syntax
 ads_keywords = [

--- a/docs/ads.rst
+++ b/docs/ads.rst
@@ -164,7 +164,7 @@ Restrict searches to articles or peer-reviewed articles:
 Add entries and fetch/open PDFs right after the ADS search:
 
 .. code-block:: shell
-  :emphasize-lines: 2, 4, 16, 20, 22, 34, 38, 40, 52
+  :emphasize-lines: 2, 4, 16
 
   # Search and prompt to open a PDF right after (fetched PDF is not stored in database):
   bibm ads-search -o
@@ -183,6 +183,8 @@ Add entries and fetch/open PDFs right after the ADS search:
        or:  bibcode: BIBCODE_VALUE FILENAME
   bibcode: 2019ApJ...880L..16F Fortney2019.pdf
 
+.. code-block:: shell
+  :emphasize-lines: 2, 4, 16
 
   # Search and prompt to add entry to database right after:
   bibm ads-search -a
@@ -201,6 +203,8 @@ Add entries and fetch/open PDFs right after the ADS search:
   separated by blanks (press META+ENTER or ESCAPE ENTER when done):
   2019ApJ...880L..16F FortneyEtal2019apjPhotosphericRadius
 
+.. code-block:: shell
+  :emphasize-lines: 2, 4, 16
 
   # Search and prompt to add entry and fetch/open its PDF right after:
   bibm ads-search -a -f
@@ -280,7 +284,7 @@ bibmanager database.
 **Examples**
 
 .. code-block:: shell
-  :emphasize-lines: 2, 4, 14, 17, 21, 24, 28, 32, 35, 39, 40
+  :emphasize-lines: 2, 4
 
   # Let's search and add the greatest astronomy PhD thesis of all times:
   bibm ads-search
@@ -293,9 +297,15 @@ bibmanager database.
   adsurl:  https://ui.adsabs.harvard.edu/abs/1925PhDT.........1P
   bibcode: 1925PhDT.........1P
 
+.. code-block:: shell
 
   # Add the entry to the bibmanager database:
   bibm ads-add 1925PhDT.........1P Payne1925phdStellarAtmospheres
+
+The user can optionally assign tags or request to fetch/open PDFs:
+
+.. code-block:: shell
+  :emphasize-lines: 2, 6, 9
 
   # Add the entry and assign a 'stars' tag to it:
   bibm ads-add 1925PhDT.........1P Payne1925phdStellarAtmospheres stars
@@ -307,6 +317,10 @@ bibmanager database.
   # Add the entry and fetch/open its PDF:
   bibm ads-add -o 1925PhDT.........1P Payne1925phdStellarAtmospheres
 
+Alternatively, the call can be done without arguments, which allow the user to request multiple entries at once (and as above, set tags to each entry as desired):
+
+.. code-block:: shell
+  :emphasize-lines: 2, 6, 9, 13, 14
 
   # A call without bibcode,key arguments (interactive prompt):
   bibm ads-add

--- a/docs/ads.rst
+++ b/docs/ads.rst
@@ -231,7 +231,7 @@ Add entries from ADS by bibcode into the bibmanager database.
 
 .. code-block:: shell
 
-  bibm ads-add [-h] [-f] [-o] [bibcode key]
+  bibm ads-add [-h] [-f] [-o] [bibcode key] [tag1 [tag2 ...]]
 
 **Description**
 
@@ -250,6 +250,10 @@ bibmanager database.
   associated PDF files of the added entries.
 | *(New since version 1.2.7)*
 
+| Either at ``bibm ads-add`` or later via the prompt you can specify
+  tags for the entries to be add.
+| *(New since version 1.4)*
+
 **Options**
 
 | **bibcode**
@@ -257,6 +261,10 @@ bibmanager database.
 |
 | **key**
 |       BibTeX key to assign to the entry.
+|
+| **tags**
+|       Optional BibTeX tags to assign to the entries.
+|       *(New since version 1.4)*
 |
 | **-f, -\\-fetch**
 |       Fetch the PDF of the added entries.
@@ -272,6 +280,7 @@ bibmanager database.
 **Examples**
 
 .. code-block:: shell
+  :emphasize-lines: 2, 4, 14, 17, 21, 24, 28, 32, 35, 39, 40
 
   # Let's search and add the greatest astronomy PhD thesis of all times:
   bibm ads-search
@@ -288,12 +297,31 @@ bibmanager database.
   # Add the entry to the bibmanager database:
   bibm ads-add 1925PhDT.........1P Payne1925phdStellarAtmospheres
 
+  # Add the entry and assign a 'stars' tag to it:
+  bibm ads-add 1925PhDT.........1P Payne1925phdStellarAtmospheres stars
+
 
   # Add the entry and fetch its PDF:
   bibm ads-add -f 1925PhDT.........1P Payne1925phdStellarAtmospheres
 
   # Add the entry and fetch/open its PDF:
   bibm ads-add -o 1925PhDT.........1P Payne1925phdStellarAtmospheres
+
+
+  # A call without bibcode,key arguments (interactive prompt):
+  bibm ads-add
+  Enter pairs of ADS bibcodes and BibTeX keys (plus optional tags)
+  Use one line for each BibTeX entry, separate fields with blank spaces.
+  (press META+ENTER or ESCAPE ENTER when done):
+  1925PhDT.........1P Payne1925phdStellarAtmospheres stars
+
+  # Multiple entries at once, assigning tags (interactive prompt):
+  bibm ads-add
+  Enter pairs of ADS bibcodes and BibTeX keys (plus optional tags)
+  Use one line for each BibTeX entry, separate fields with blank spaces.
+  (press META+ENTER or ESCAPE ENTER when done):
+  1925PhDT.........1P Payne1925phdStellarAtmospheres stars
+  1957RvMP...29..547B BurbidgeEtal1957rvmpStellarSynthesis stars nucleosynthesis
 
 ----------------------------------------------------------------------
 

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -15,7 +15,7 @@ ______________________
 
 .. py:module:: bibmanager.bib_manager
 
-.. py:class:: Bib(entry, pdf=None, freeze=None)
+.. py:class:: Bib(entry, pdf=None, freeze=None, tags=[])
 
 .. code-block:: pycon
 
@@ -96,6 +96,27 @@ ______________________
            title  = {SciPy: Open source scientific tools for Python},
            year   = {2001},
          }
+
+.. py:function:: display_list(bibs, verb=-1)
+.. code-block:: pycon
+
+    Display a list of BibTeX entries with different verbosity levels.
+
+    Although this might seem a duplication of display_bibs(), this
+    function is meant to provide multiple levels of verbosity and
+    generally to display longer lists of entries.
+
+    Parameters
+    ----------
+    bibs: List of Bib() objects
+        BibTeX entries to display.
+    verb: Integer
+        The desired verbosity level:
+        verb < 0: Display only the keys.
+        verb = 0: Display the title, year, first author, and key.
+        verb = 1: Display additionally the ADS and arXiv urls.
+        verb = 2: Display additionally the full list of authors.
+        verb > 2: Display the full BibTeX entry.
 
 .. py:function:: remove_duplicates(bibs, field)
 .. code-block:: pycon
@@ -337,7 +358,7 @@ ______________________
     https://stackoverflow.com/questions/17317219/
     https://docs.python.org/3.6/library/subprocess.html
 
-.. py:function:: search(authors=None, year=None, title=None, key=None, bibcode=None)
+.. py:function:: search(authors=None, year=None, title=None, key=None, bibcode=None, tags=None)
 .. code-block:: pycon
 
     Search in bibmanager database by authors, year, or title keywords.
@@ -357,6 +378,8 @@ ______________________
         Match any entry whose key is in the input key.
     bibcode: String or list of strings
         Match any entry whose bibcode is in the input bibcode.
+    tags: String or list of strings
+        Match entries containing all specified tags.
 
     Returns
     -------
@@ -434,6 +457,26 @@ ______________________
     bibcode: 2013A&A...558A..33A
     >>> print(prompt_input[0])
     [None, '2013A&A...558A..33A']
+
+.. py:function:: prompt_search_tags(prompt_text)
+.. code-block:: pycon
+
+    Do an interactive prompt search in the Bibmanager database by
+    the given keywords, with auto-complete and auto-suggest only
+    offering non-None values of the given field.
+    Only one keyword must be set in the prompt.
+    A bottom toolbar dynamically shows additional info.
+
+    Parameters
+    ----------
+    prompt_text: String
+        Text to display when launching the prompt.
+
+    Returns
+    -------
+    kw_input: List of strings
+        List of the parsed input (same order as keywords).
+        Items are None for the keywords not defined.
 
 .. py:function:: browse()
 .. code-block:: pycon
@@ -587,12 +630,12 @@ ________________________
     % This is a comment line.
     This line ends with a comment. % A comment
     However, this is a percentage \%, not a comment.
-    OK, byee.'''
+    OK, bye.'''
     >>> print(lm.no_comments(text))
     Hello, this is dog.
     This line ends with a comment.
     However, this is a percentage \%, not a comment.
-    OK, byee.
+    OK, bye.
 
 .. py:function:: citations(text)
 .. code-block:: pycon
@@ -657,7 +700,7 @@ ________________________
     AuthorA AuthorB AuthorC AuthorD AuthorE AuthorF AuthorG AuthorH AuthorI AuthorJ AuthorK AuthorL AuthorM AuthorN AuthorO AuthorP AuthorQ AuthorR AuthorS AuthorT AuthorU AuthorV AuthorW AuthorX AuthorY AuthorZ AuthorAA
 
     >>> texfile = os.path.expanduser('~')+"/.bibmanager/examples/sample.tex"
-    >>> with open(texfile) as f:
+    >>> with open(texfile, encoding='utf-8') as f:
     >>>     tex = f.read()
     >>> tex = lm.no_comments(tex)
     >>> cites = [citation for citation in lm.citations(tex)]
@@ -859,7 +902,7 @@ ______________________
     >>> results, nmatch = am.search(query, start=start)
     >>> display(results, start, index, rows, nmatch)
 
-.. py:function:: add_bibtex(input_bibcodes, input_keys, eprints=[], dois=[], update_keys=True, base=None)
+.. py:function:: add_bibtex(input_bibcodes, input_keys, eprints=[], dois=[], update_keys=True, base=None, tags=None)
 .. code-block:: pycon
 
     Add bibtex entries from a list of ADS bibcodes, with specified keys.
@@ -882,6 +925,8 @@ ______________________
     base: List of Bib() objects
         If None, merge new entries into the bibmanager database.
         If not None, merge new entries into base.
+    tags: Nested list of strings
+        The list of tags for each input bibcode.
 
     Returns
     -------
@@ -1163,11 +1208,6 @@ ________________
 
   '\n::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::\n'
 
-.. py:data:: search_keywords
-.. code-block:: pycon
-
-  ['author:"^"', 'author:""', 'year:', 'title:""', 'key:', 'bibcode:']
-
 .. py:data:: ads_keywords
 .. code-block:: pycon
 
@@ -1204,6 +1244,11 @@ ________________
     ADS search history
 
 .. py:function:: BM_HISTORY_PDF()
+.. code-block:: pycon
+
+    PDF search history
+
+.. py:function:: BM_HISTORY_TAGS()
 .. code-block:: pycon
 
     PDF search history
@@ -1509,9 +1554,9 @@ ________________
     Parameters
     ----------
     name: String
-       Name to be 'purified'.
+        Name to be 'purified'.
     german: Bool
-       Replace umlaut with german style (append 'e' after).
+        Replace umlaut with german style (append 'e' after).
 
     Returns
     -------
@@ -1771,21 +1816,69 @@ ________________
 
     Custom format for warnings.
 
-.. py:class:: AutoSuggestCompleter()
+.. py:function:: tokenizer(attribute, value, value_token=Token.Literal.String)
+.. code-block:: pycon
+
+        Shortcut to generate formatted-text tokens for attribute-value texts.
+
+        The attribute is set in a Token.Name.Attribute style, followed
+        by a colon (Token.Punctuation style), and followed by the value
+        (in value_token style).
+
+        Parameters
+        ----------
+        attribute: String
+            Name of the attribute.
+        value: String
+            The attribute's value.
+        value_token: a pygments.token object
+            The style for the attribute's value.
+
+        Returns
+        -------
+        tokens: List of (style, text) tuples.
+            Tuples that can lated be fed into a FormattedText() or
+            other prompt_toolkit text formatting calls.
+
+        Examples
+        --------
+        >>> import bibmanager.utils as u
+
+        >>> tokens = u.tokenizer('Title', 'Synthesis of the Elements in Stars')
+        >>> print(tokens)
+        [(Token.Name.Attribute, 'Title'),
+         (Token.Punctuation, ': '),
+         (Token.Literal.String, 'Synthesis of the Elements in Stars'),
+         (Token.Text, '
+    ')]
+
+        >>> # Pretty printing:
+        >>> import prompt_toolkit
+        >>> from prompt_toolkit.formatted_text import PygmentsTokens
+        >>> from pygments.styles import get_style_by_name
+
+        >>> style = prompt_toolkit.styles.style_from_pygments_cls(
+        >>>     get_style_by_name('autumn'))
+        >>> prompt_toolkit.print_formatted_text(
+        >>>     PygmentsTokens(tokens), style=style)
+        Title: Synthesis of the Elements in Stars
+    
+
+.. py:class:: DynamicKeywordCompleter(key_words)
 
 .. code-block:: pycon
 
-    Give suggestions based on the words in WordCompleter.
+    Provide tab-completion for keys and words in corresponding key.
 
   .. code-block:: pycon
 
     Initialize self.  See help(type(self)) for accurate signature.
 
-.. py:class:: AutoSuggestKeyCompleter()
+.. py:class:: DynamicKeywordSuggester()
 
 .. code-block:: pycon
 
-    Give suggestions based on the words in WordCompleter.
+    Give dynamic suggestions as in DynamicKeywordCompleter.
 
   .. code-block:: pycon
 
@@ -1811,6 +1904,52 @@ ________________
     :param pattern: Optional compiled regex for finding the word before
         the cursor to complete. When given, use this regex pattern instead of
         default one (see document._FIND_WORD_RE)
+
+  .. code-block:: pycon
+
+    Initialize self.  See help(type(self)) for accurate signature.
+
+.. py:class:: AutoSuggestCompleter()
+
+.. code-block:: pycon
+
+    Give suggestions based on the words in WordCompleter.
+
+  .. code-block:: pycon
+
+    Initialize self.  See help(type(self)) for accurate signature.
+
+.. py:class:: AutoSuggestKeyCompleter()
+
+.. code-block:: pycon
+
+    Give suggestions based on the words in WordCompleter.
+
+  .. code-block:: pycon
+
+    Initialize self.  See help(type(self)) for accurate signature.
+
+.. py:class:: LastKeyCompleter(key_words)
+
+.. code-block:: pycon
+
+    Give completer options according to last key found in input.
+
+  .. code-block:: pycon
+
+    Parameters
+    ----------
+    key_words: Dict
+        Dictionary containing the available keys and the
+        set of words corresponding to each key.
+        An empty-string key denotes the default set of words to
+        show when no key is found in the input text.
+
+.. py:class:: LastKeySuggestCompleter()
+
+.. code-block:: pycon
+
+    Give suggestions based on the keys and words in LastKeyCompleter.
 
   .. code-block:: pycon
 

--- a/docs/bibtex.rst
+++ b/docs/bibtex.rst
@@ -173,6 +173,9 @@ Meta-Information
   in the *home/pdf* folder (see :ref:`config`), there's no need to specify
   the path to the file.  Alternatively, see the commands in :ref:`pdf`.
 
+- The *tags* meta-parameter enable setting user-defined tags for
+  grouping and searching entries *(New since Version 1.4)*
+
 Below there's an example to freeze and link a PDF file to an entry:
 
 .. code-block:: shell
@@ -243,6 +246,50 @@ to check for duplicates: doi, isbn, bibcode, and eprint.
 
   # Start multi-line prompt session to enter one or more BibTeX entries:
   bibm add
+
+
+--------------------------------------------------------------------
+
+tag
+---
+
+Add or remove tags to entries in the database.
+
+**Usage**
+
+.. code-block:: shell
+
+  bibm tag [-h] [-d]
+
+**Description**
+
+| This command adds or removes user-defined tags to specified entries in the Bibmanager database, which can then be used for grouping and searches.  The tags are case sensitive and should not contain blank spaces.
+| *(New since version 1.4)*
+
+**Options**
+
+| **-h, -\\-help**
+|       Show this help message and exit.
+| **-d, -\\-delete** Delete tags instead of add.
+
+**Examples**
+
+.. code-block:: shell
+
+  # Add a tag to an entry:
+  bibm tag
+  (Syntax is: KEY_OR_BIBCODE KEY_OR_BIBCODE2 ... tags: TAG TAG2 ...)
+  Hunter2007ieeeMatplotlib tag: python
+
+  # Add multiple tags to multiple entries:
+  bibm tag
+  (Syntax is: KEY_OR_BIBCODE KEY_OR_BIBCODE2 ... tags: TAG TAG2 ...)
+  1913LowOB...2...56S 1918ApJ....48..154S tags: galaxies history
+
+  # Remove tags:
+  bibm tag -d
+  (Syntax is: KEY_OR_BIBCODE KEY_OR_BIBCODE2 ... tags: TAG TAG2 ...)
+  Slipher1913lobAndromedaRarialVelocity tags: galaxies
 
 --------------------------------------------------------------------
 
@@ -549,7 +596,6 @@ Use the ``-v`` command to increase verbosity:
   }
 
 --------------------------------------------------------------------
-
 
 browse
 ------

--- a/docs/bibtex.rst
+++ b/docs/bibtex.rst
@@ -259,18 +259,30 @@ Add or remove tags to entries in the database.
 
 .. code-block:: shell
 
-  bibm tag [-h] [-d]
+  bibm tag [-h] [-d] [-v VERB]
 
 **Description**
 
 | This command adds or removes user-defined tags to specified entries in the Bibmanager database, which can then be used for grouping and searches.  The tags are case sensitive and should not contain blank spaces.
 | *(New since version 1.4)*
 
+| Additionally, if the user only sets tags (but no entries), this
+  command will display the existing entries that contain those tags.
+| There are five levels of verbosity:
+| verb < 0:  Display only the keys of the entries
+| verb = 0:  Display the title, year, first author, and key
+| verb = 1:  Display additionally the ADS/arXiv urls and meta info
+| verb = 2:  Display additionally the full list of authors
+| verb > 2:  Display the full BibTeX entries
+
 **Options**
 
 | **-h, -\\-help**
 |       Show this help message and exit.
-| **-d, -\\-delete** Delete tags instead of add.
+| **-d, -\\-delete**
+|       Delete tags instead of add.
+| **-v VERB, -\\-verb VERB**
+|       Verbosity level if used to display entries.
 
 **Examples**
 
@@ -290,6 +302,12 @@ Add or remove tags to entries in the database.
   bibm tag -d
   (Syntax is: KEY_OR_BIBCODE KEY_OR_BIBCODE2 ... tags: TAG TAG2 ...)
   Slipher1913lobAndromedaRarialVelocity tags: galaxies
+
+
+  # Display all entries that contain the 'galaxies' tag:
+  bibm tag
+  (Syntax is: KEY_OR_BIBCODE KEY_OR_BIBCODE2 ... tags: TAG TAG2 ...)
+  tags: galaxies
 
 --------------------------------------------------------------------
 

--- a/docs/bibtex.rst
+++ b/docs/bibtex.rst
@@ -322,7 +322,7 @@ Search entries in the bibmanager database.
 
 .. code-block:: shell
 
-  bibm search [-h] [-v]
+  bibm search [-h] [-v VERB]
 
 **Description**
 
@@ -336,11 +336,12 @@ Multiple author, title keyword, and year queries act with AND logic;
 whereas multiple-key queries and multiple-bibcode queries act with OR
 logic (see examples below).
 
-| There are four levels of verbosity (see examples below):
-| - zero shows the title, year, first author, and key;
-| - one adds the ADS and arXiv urls;
-| - two adds the full list of authors;
-| - and three displays the full BibTeX entry.
+| There are five levels of verbosity:
+| verb < 0:  Display only the keys of the entries
+| verb = 0:  Display the title, year, first author, and key
+| verb = 1:  Display additionally the ADS/arXiv urls and meta info
+| verb = 2:  Display additionally the full list of authors
+| verb > 2:  Display the full BibTeX entries
 
 .. note::
   (1) There's no need to worry about case in author names, unless they
@@ -355,7 +356,7 @@ logic (see examples below).
 
 **Options**
 
-| **-v, -\\-verb**
+| **-v VERB, -\\-verb VERB**
 |           Set output verbosity.
 |
 | **-h, -\\-help**
@@ -563,12 +564,24 @@ Search multiple keys (same applies to multiple-bibcodes searches):
   key: Shapley1918apjDistanceGlobularClusters
 
 
-Use the ``-v`` command to increase verbosity:
+Use the ``-v VERB`` command to set the verbosity:
+
+.. code-block:: shell
+
+  # Display only the keys:
+  bibm search -v -1
+  (Press 'tab' for autocomplete)
+  year: 1910-1920
+
+  Keys:
+  Curtis1917paspIslandUniverseTheory
+  Shapley1918apjDistanceGlobularClusters
+  Slipher1913lobAndromedaRarialVelocity
 
 .. code-block:: shell
 
   # Display title, year, first author, and all keys/urls:
-  bibm search -v
+  bibm search -v 1
   (Press 'tab' for autocomplete)
   author:"Burbidge, E"
 
@@ -580,8 +593,8 @@ Use the ``-v`` command to increase verbosity:
 
 .. code-block:: shell
 
-  # Display title, year, full author list, and all keys/urls:
-  bibm search -vv
+  # Display title, year, full author list, URLs, and meta info:
+  bibm search -v 2
   (Press 'tab' for autocomplete)
   author:"Burbidge, E"
 
@@ -595,7 +608,7 @@ Use the ``-v`` command to increase verbosity:
 .. code-block:: shell
 
   # Display full BibTeX entry:
-  bibm search -vvv
+  bibm search -v 3
   (Press 'tab' for autocomplete)
   author:"Burbidge, E"
 
@@ -618,7 +631,8 @@ Use the ``-v`` command to increase verbosity:
 browse
 ------
 
-Browse through the bibmanager database.
+| Browse through the bibmanager database.
+| *(New since version 1.3)*
 
 **Usage**
 
@@ -628,13 +642,13 @@ Browse through the bibmanager database.
 
 **Description**
 
-| Display the entire bibmanager database into a full-screen application that lets you:
+| Display the entire bibmanager database in an interactive full-screen application that lets you:
 |  - Navigate through or search for specific entries
 |  - Visualize the entries' full BibTeX content
 |  - Select entries for printing to screen or to file
 |  - Open the entries' PDF files
 |  - Open the entries in ADS through the web browser
-| *(New since version 1.3)*
+|  - Select sub-group of entries by tags  *(New since version 1.4)*
 
 **Options**
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -30,6 +30,7 @@ Features
 * Clean up (remove duplicates, ADS update) any external bibfile (since version 1.1.2)
 * Keep a database of the entries' PDFs and fetch PDFs from ADS (since version 1.2)
 * Browse interactively through the database (since version 1.3)
+* Keep track of the more relevant entries using custom-set tags (since version 1.4)
 
 ``bibmanager`` also simplifies many other BibTeX-related tasks:
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -549,6 +549,10 @@ def reqs(requests_mock):
     folsom = {'msg': 'Retrieved 1 abstracts, starting with number 1.',
  'export': '@ARTICLE{2018MNRAS.481.5286F,\n       author = {{Folsom}, C.~P. and {Fossati}, L. and {Wood}, B.~E. and {Sreejith},\n        A.~G. and {Cubillos}, P.~E. and {Vidotto}, A.~A. and {Alecian},\n        E. and {Girish}, V. and {Lichtenegger}, H. and {Murthy}, J. and\n        {Petit}, P. and {Valyavin}, G.},\n        title = "{Characterization of the HD 219134 multiplanet system I. Observations of stellar magnetism, wind, and high-energy flux}",\n      journal = {\\mnras},\n     keywords = {techniques: polarimetric, stars: individual: HD 219134, stars: late-type, stars: magnetic field, stars: winds, outflows, Astrophysics - Solar and Stellar Astrophysics, Astrophysics - Earth and Planetary Astrophysics},\n         year = 2018,\n        month = Dec,\n       volume = {481},\n        pages = {5286-5295},\n          doi = {10.1093/mnras/sty2494},\narchivePrefix = {arXiv},\n       eprint = {1808.00406},\n primaryClass = {astro-ph.SR},\n       adsurl = {https://ui.adsabs.harvard.edu/abs/2018MNRAS.481.5286F},\n      adsnote = {Provided by the SAO/NASA Astrophysics Data System}\n}\n\n'}
 
+    payne_burbidge = {
+        'msg': 'Retrieved 2 abstracts, starting with number 1.',
+        'export': '@ARTICLE{1957RvMP...29..547B,\n       author = {{Burbidge}, E. Margaret and {Burbidge}, G.~R. and {Fowler}, William A. and {Hoyle}, F.},\n        title = "{Synthesis of the Elements in Stars}",\n      journal = {Reviews of Modern Physics},\n         year = 1957,\n        month = jan,\n       volume = {29},\n       number = {4},\n        pages = {547-650},\n          doi = {10.1103/RevModPhys.29.547},\n       adsurl = {https://ui.adsabs.harvard.edu/abs/1957RvMP...29..547B},\n      adsnote = {Provided by the SAO/NASA Astrophysics Data System}\n}\n\n' + payne['export']
+    }
 
     # The mocks:
     start, cache_rows, sort = 0, 200, 'pubdate+desc'  #am.search.__defaults__
@@ -601,22 +605,33 @@ def reqs(requests_mock):
 
     def request_payne(request):
         return '1925PhDT.........1P' in request.text
+    def request_payne_burbidge(request):
+        return ('1925PhDT.........1P' in request.text and
+                '1957RvMP...29..547B' in request.text)
     def request_invalid(request):
         return '1925PhDT.....X...1P' in request.text
     def request_invalid_folsom(request):
         return ('1925PhDT.....X...1P' in request.text and
                 '2018MNRAS.481.5286F' in request.text)
 
-    requests_mock.post("https://api.adsabs.harvard.edu/v1/export/bibtex",
+    requests_mock.post(
+        "https://api.adsabs.harvard.edu/v1/export/bibtex",
         additional_matcher=request_payne,
         json=payne)
 
-    requests_mock.post("https://api.adsabs.harvard.edu/v1/export/bibtex",
+    requests_mock.post(
+        "https://api.adsabs.harvard.edu/v1/export/bibtex",
+        additional_matcher=request_payne_burbidge,
+        json=payne_burbidge)
+
+    requests_mock.post(
+        "https://api.adsabs.harvard.edu/v1/export/bibtex",
         additional_matcher=request_invalid,
         status_code=404,
         json={'error': 'no result from solr'})
 
-    requests_mock.post("https://api.adsabs.harvard.edu/v1/export/bibtex",
+    requests_mock.post(
+        "https://api.adsabs.harvard.edu/v1/export/bibtex",
         additional_matcher=request_invalid_folsom,
         json=folsom)
 

--- a/tests/test_ads.py
+++ b/tests/test_ads.py
@@ -74,7 +74,7 @@ def test_search_unauthorized(reqs, mock_init):
         results, nmatch = am.search(query)
 
 
-def test_display_all(capsys, ads_entries):
+def test_display_all(capsys, mock_init, ads_entries):
     results = [ads_entries['fortney2018'], ads_entries['fortney2016']]
     start  = 0
     index  = 0
@@ -86,7 +86,7 @@ def test_display_all(capsys, ads_entries):
         expected_output1 + 'Showing entries 1--2 out of 2 matches.\n'
 
 
-def test_display_first_batch(capsys, ads_entries):
+def test_display_first_batch(capsys, mock_init, ads_entries):
     results = [
         ads_entries['fortney2018'],
         ads_entries['fortney2016'],
@@ -104,7 +104,7 @@ def test_display_first_batch(capsys, ads_entries):
         'To show the next set, execute:\nbibm ads-search -n\n')
 
 
-def test_display_second_batch(capsys, ads_entries):
+def test_display_second_batch(capsys, mock_init, ads_entries):
     results = [
         ads_entries['fortney2018'],
         ads_entries['fortney2016'],
@@ -120,7 +120,7 @@ def test_display_second_batch(capsys, ads_entries):
         expected_output2 + 'Showing entries 3--4 out of 4 matches.\n'
 
 
-def test_display_over(capsys, ads_entries):
+def test_display_over(capsys, mock_init, ads_entries):
     results = [
         ads_entries['fortney2018'],
         ads_entries['fortney2016'],

--- a/tests/test_ads.py
+++ b/tests/test_ads.py
@@ -217,6 +217,31 @@ Merged 1 new entries.
 (Not counting updated references)\n"""
 
 
+def test_add_bibtex_with_tags(capsys, reqs, mock_init):
+    captured = capsys.readouterr()
+    bibcodes = ['1925PhDT.........1P']
+    keys = ['Payne1925phdStellarAtmospheres']
+    tags = [['stars']]
+    am.add_bibtex(bibcodes, keys, tags=tags)
+    captured = capsys.readouterr()
+    assert captured.out == "\nMerged 1 new entries.\n" \
+                           "(Not counting updated references)\n"
+    loaded_bibs = bm.load()
+    assert len(loaded_bibs) == 1
+    assert repr(loaded_bibs[0]) == \
+"""tags: stars
+@PHDTHESIS{Payne1925phdStellarAtmospheres,
+       author = {{Payne}, Cecilia Helena},
+        title = "{Stellar Atmospheres; a Contribution to the Observational Study of High Temperature in the Reversing Layers of Stars.}",
+     keywords = {Astronomy},
+       school = {RADCLIFFE COLLEGE.},
+         year = 1925,
+        month = Jan,
+       adsurl = {https://ui.adsabs.harvard.edu/abs/1925PhDT.........1P},
+      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}"""
+
+
 @pytest.mark.skip(reason="Can I test this without monkeypatching the request?")
 def test_update(capsys, mock_init_sample):
     captured = capsys.readouterr()

--- a/tests/test_ads.py
+++ b/tests/test_ads.py
@@ -10,6 +10,11 @@ import bibmanager.config_manager as cm
 import bibmanager.utils as u
 
 
+expected_output1 = '\x1b[0m\x1b[?7h\x1b[0m\r\n\x1b[0;38;5;33mTitle\x1b[0m: \x1b[0;38;5;130mA deeper look at Jupiter\x1b[0m\r\n\x1b[0;38;5;33mAuthors\x1b[0m: \x1b[0;38;5;130mFortney, Jonathan\x1b[0m\r\n\x1b[0;38;5;33mADS URL\x1b[0m: \x1b[0;38;5;130mhttps://ui.adsabs.harvard.edu/abs/2018Natur.555..168F\x1b[0m\r\n\x1b[0;38;5;33mbibcode\x1b[0m: \x1b[0;38;5;142m2018Natur.555..168F\x1b[0m\r\n\x1b[0m\x1b[0m\x1b[?7h\x1b[0m\r\n\x1b[0;38;5;33mTitle\x1b[0m: \x1b[0;38;5;130mThe Hunt for Planet Nine: Atmosphere, Spectra, Evolution, and\r\n    Detectability\x1b[0m\r\n\x1b[0;38;5;33mAuthors\x1b[0m: \x1b[0;38;5;130mFortney, Jonathan J.; et al.\x1b[0m\r\n\x1b[0;38;5;33mADS URL\x1b[0m: \x1b[0;38;5;130mhttps://ui.adsabs.harvard.edu/abs/2016ApJ...824L..25F\x1b[0m\r\n\x1b[0;38;5;33mbibcode\x1b[0m: \x1b[0;38;5;142m2016ApJ...824L..25F\x1b[0m\r\n\x1b[0m\n'
+
+expected_output2 = '\x1b[0m\x1b[?7h\x1b[0m\r\n\x1b[0;38;5;33mTitle\x1b[0m: \x1b[0;38;5;130mA Framework for Characterizing the Atmospheres of Low-mass Low-density\r\n    Transiting Planets\x1b[0m\r\n\x1b[0;38;5;33mAuthors\x1b[0m: \x1b[0;38;5;130mFortney, Jonathan J.; et al.\x1b[0m\r\n\x1b[0;38;5;33mADS URL\x1b[0m: \x1b[0;38;5;130mhttps://ui.adsabs.harvard.edu/abs/2013ApJ...775...80F\x1b[0m\r\n\x1b[0;38;5;33mbibcode\x1b[0m: \x1b[0;38;5;142m2013ApJ...775...80F\x1b[0m\r\n\x1b[0m\x1b[0m\x1b[?7h\x1b[0m\r\n\x1b[0;38;5;33mTitle\x1b[0m: \x1b[0;38;5;130mOn the Carbon-to-oxygen Ratio Measurement in nearby Sun-like Stars:\r\n    Implications for Planet Formation and the Determination of Stellar\r\n    Abundances\x1b[0m\r\n\x1b[0;38;5;33mAuthors\x1b[0m: \x1b[0;38;5;130mFortney, Jonathan J.\x1b[0m\r\n\x1b[0;38;5;33mADS URL\x1b[0m: \x1b[0;38;5;130mhttps://ui.adsabs.harvard.edu/abs/2012ApJ...747L..27F\x1b[0m\r\n\x1b[0;38;5;33mbibcode\x1b[0m: \x1b[0;38;5;142m2012ApJ...747L..27F\x1b[0m\r\n\x1b[0m\n'
+
+
 def test_key_update_journal_year():
     # Case of journal does not matter:
     assert am.key_update("BeaulieuEtal2010ArXiVGJ436b", "2011ApJ...731...16B",
@@ -77,90 +82,58 @@ def test_display_all(capsys, ads_entries):
     nmatch = 2
     am.display(results, start, index, rows, nmatch, short=True)
     captured = capsys.readouterr()
-    assert captured.out == f"""
-Title: A deeper look at Jupiter
-Authors: Fortney, Jonathan
-adsurl:  https://ui.adsabs.harvard.edu/abs/2018Natur.555..168F
-{u.BOLD}bibcode{u.END}: 2018Natur.555..168F
-
-Title: The Hunt for Planet Nine: Atmosphere, Spectra, Evolution, and
-       Detectability
-Authors: Fortney, Jonathan J.; et al.
-adsurl:  https://ui.adsabs.harvard.edu/abs/2016ApJ...824L..25F
-{u.BOLD}bibcode{u.END}: 2016ApJ...824L..25F
-
-Showing entries 1--2 out of 2 matches.\n"""
+    assert captured.out == \
+        expected_output1 + 'Showing entries 1--2 out of 2 matches.\n'
 
 
 def test_display_first_batch(capsys, ads_entries):
-    results = [ads_entries['fortney2018'], ads_entries['fortney2016'],
-               ads_entries['fortney2013'], ads_entries['fortney2012']]
+    results = [
+        ads_entries['fortney2018'],
+        ads_entries['fortney2016'],
+        ads_entries['fortney2013'],
+        ads_entries['fortney2012']]
     start  = 0
     index  = 0
     rows   = 2
     nmatch = 4
     am.display(results, start, index, rows, nmatch, short=True)
     captured = capsys.readouterr()
-    assert captured.out == f"""
-Title: A deeper look at Jupiter
-Authors: Fortney, Jonathan
-adsurl:  https://ui.adsabs.harvard.edu/abs/2018Natur.555..168F
-{u.BOLD}bibcode{u.END}: 2018Natur.555..168F
-
-Title: The Hunt for Planet Nine: Atmosphere, Spectra, Evolution, and
-       Detectability
-Authors: Fortney, Jonathan J.; et al.
-adsurl:  https://ui.adsabs.harvard.edu/abs/2016ApJ...824L..25F
-{u.BOLD}bibcode{u.END}: 2016ApJ...824L..25F
-
-Showing entries 1--2 out of 4 matches.  To show the next set, execute:
-bibm ads-search -n\n"""
+    assert captured.out == (
+        expected_output1 +
+        'Showing entries 1--2 out of 4 matches.  '
+        'To show the next set, execute:\nbibm ads-search -n\n')
 
 
 def test_display_second_batch(capsys, ads_entries):
-    results = [ads_entries['fortney2018'], ads_entries['fortney2016'],
-               ads_entries['fortney2013'], ads_entries['fortney2012']]
+    results = [
+        ads_entries['fortney2018'],
+        ads_entries['fortney2016'],
+        ads_entries['fortney2013'],
+        ads_entries['fortney2012']]
     start  = 0
     index  = 2
     rows   = 2
     nmatch = 4
     am.display(results, start, index, rows, nmatch, short=True)
     captured = capsys.readouterr()
-    assert captured.out == f"""
-Title: A Framework for Characterizing the Atmospheres of Low-mass Low-density
-       Transiting Planets
-Authors: Fortney, Jonathan J.; et al.
-adsurl:  https://ui.adsabs.harvard.edu/abs/2013ApJ...775...80F
-{u.BOLD}bibcode{u.END}: 2013ApJ...775...80F
-
-Title: On the Carbon-to-oxygen Ratio Measurement in nearby Sun-like Stars:
-       Implications for Planet Formation and the Determination of Stellar
-       Abundances
-Authors: Fortney, Jonathan J.
-adsurl:  https://ui.adsabs.harvard.edu/abs/2012ApJ...747L..27F
-{u.BOLD}bibcode{u.END}: 2012ApJ...747L..27F
-
-Showing entries 3--4 out of 4 matches.\n"""
+    assert captured.out == \
+        expected_output2 + 'Showing entries 3--4 out of 4 matches.\n'
 
 
 def test_display_over(capsys, ads_entries):
-    results = [ads_entries['fortney2018'], ads_entries['fortney2016'],
-               ads_entries['fortney2013'], ads_entries['fortney2012']]
+    results = [
+        ads_entries['fortney2018'],
+        ads_entries['fortney2016'],
+        ads_entries['fortney2013'],
+        ads_entries['fortney2012']]
     start  = 0
     index  = 3
     rows   = 2
     nmatch = 4
     am.display(results, start, index, rows, nmatch, short=True)
     captured = capsys.readouterr()
-    assert captured.out == f"""
-Title: On the Carbon-to-oxygen Ratio Measurement in nearby Sun-like Stars:
-       Implications for Planet Formation and the Determination of Stellar
-       Abundances
-Authors: Fortney, Jonathan J.
-adsurl:  https://ui.adsabs.harvard.edu/abs/2012ApJ...747L..27F
-{u.BOLD}bibcode{u.END}: 2012ApJ...747L..27F
-
-Showing entries 4--4 out of 4 matches.\n"""
+    expected_output = '\x1b[0m\x1b[?7h\x1b[0m\r\n\x1b[0;38;5;33mTitle\x1b[0m: \x1b[0;38;5;130mOn the Carbon-to-oxygen Ratio Measurement in nearby Sun-like Stars:\r\n    Implications for Planet Formation and the Determination of Stellar\r\n    Abundances\x1b[0m\r\n\x1b[0;38;5;33mAuthors\x1b[0m: \x1b[0;38;5;130mFortney, Jonathan J.\x1b[0m\r\n\x1b[0;38;5;33mADS URL\x1b[0m: \x1b[0;38;5;130mhttps://ui.adsabs.harvard.edu/abs/2012ApJ...747L..27F\x1b[0m\r\n\x1b[0;38;5;33mbibcode\x1b[0m: \x1b[0;38;5;142m2012ApJ...747L..27F\x1b[0m\r\n\x1b[0m\nShowing entries 4--4 out of 4 matches.\n'
+    assert captured.out == expected_output
 
 
 def test_add_bibtex_success(capsys, reqs, mock_init):
@@ -266,14 +239,8 @@ def test_manager_query_no_caching(capsys, reqs, ads_entries, mock_init):
     query = 'author:"^mayor" year:1995 property:refereed'
     am.manager(query)
     captured = capsys.readouterr()
-    assert captured.out == f"""
-Title: A Jupiter-mass companion to a solar-type star
-Authors: Mayor, Michel and Queloz, Didier
-adsurl:  https://ui.adsabs.harvard.edu/abs/1995Natur.378..355M
-{u.BOLD}bibcode{u.END}: 1995Natur.378..355M
-
-Showing entries 1--1 out of 1 matches.\n"""
-    assert not os.path.exists(u.BM_CACHE())
+    expected_output = '\x1b[0m\x1b[?7h\x1b[0m\r\n\x1b[0;38;5;33mTitle\x1b[0m: \x1b[0;38;5;130mA Jupiter-mass companion to a solar-type star\x1b[0m\r\n\x1b[0;38;5;33mAuthors\x1b[0m: \x1b[0;38;5;130mMayor, Michel and Queloz, Didier\x1b[0m\r\n\x1b[0;38;5;33mADS URL\x1b[0m: \x1b[0;38;5;130mhttps://ui.adsabs.harvard.edu/abs/1995Natur.378..355M\x1b[0m\r\n\x1b[0;38;5;33mbibcode\x1b[0m: \x1b[0;38;5;142m1995Natur.378..355M\x1b[0m\r\n\x1b[0m\nShowing entries 1--1 out of 1 matches.\n'
+    assert captured.out == expected_output
 
 
 def test_manager_query_caching(capsys, reqs, ads_entries, mock_init):
@@ -284,20 +251,10 @@ def test_manager_query_caching(capsys, reqs, ads_entries, mock_init):
     am.manager(query)
     captured = capsys.readouterr()
     assert os.path.exists(u.BM_CACHE())
-    assert captured.out == f"""
-Title: A deeper look at Jupiter
-Authors: Fortney, Jonathan
-adsurl:  https://ui.adsabs.harvard.edu/abs/2018Natur.555..168F
-{u.BOLD}bibcode{u.END}: 2018Natur.555..168F
-
-Title: The Hunt for Planet Nine: Atmosphere, Spectra, Evolution, and
-       Detectability
-Authors: Fortney, Jonathan J.; et al.
-adsurl:  https://ui.adsabs.harvard.edu/abs/2016ApJ...824L..25F
-{u.BOLD}bibcode{u.END}: 2016ApJ...824L..25F
-
-Showing entries 1--2 out of 26 matches.  To show the next set, execute:
-bibm ads-search -n\n"""
+    assert captured.out == (
+        expected_output1 +
+        'Showing entries 1--2 out of 26 matches.  To show the next set, '
+        'execute:\nbibm ads-search -n\n')
 
 
 def test_manager_from_cache(capsys, reqs, ads_entries, mock_init):
@@ -309,22 +266,7 @@ def test_manager_from_cache(capsys, reqs, ads_entries, mock_init):
     captured = capsys.readouterr()
     am.manager(None)
     captured = capsys.readouterr()
-    assert captured.out == f"""
-Title: A Framework for Characterizing the Atmospheres of Low-mass Low-density
-       Transiting Planets
-Authors: Fortney, Jonathan J.; et al.
-adsurl:  https://ui.adsabs.harvard.edu/abs/2013ApJ...775...80F
-{u.BOLD}bibcode{u.END}: 2013ApJ...775...80F
-
-Title: On the Carbon-to-oxygen Ratio Measurement in nearby Sun-like Stars:
-       Implications for Planet Formation and the Determination of Stellar
-       Abundances
-Authors: Fortney, Jonathan J.
-adsurl:  https://ui.adsabs.harvard.edu/abs/2012ApJ...747L..27F
-{u.BOLD}bibcode{u.END}: 2012ApJ...747L..27F
-
-Showing entries 3--4 out of 26 matches.  To show the next set, execute:
-bibm ads-search -n\n"""
+    assert captured.out == expected_output2 + 'Showing entries 3--4 out of 26 matches.  To show the next set, execute:\nbibm ads-search -n\n'
 
 
 def test_manager_cache_trigger_search(capsys, reqs, ads_entries, mock_init):
@@ -336,18 +278,5 @@ def test_manager_cache_trigger_search(capsys, reqs, ads_entries, mock_init):
     captured = capsys.readouterr()
     am.manager(None)
     captured = capsys.readouterr()
-    assert captured.out == f"""
-Title: Discovery and Atmospheric Characterization of Giant Planet Kepler-12b:
-       An Inflated Radius Outlier
-Authors: Fortney, Jonathan J.; et al.
-adsurl:  https://ui.adsabs.harvard.edu/abs/2011ApJS..197....9F
-{u.BOLD}bibcode{u.END}: 2011ApJS..197....9F
-
-Title: Self-consistent Model Atmospheres and the Cooling of the Solar System's
-       Giant Planets
-Authors: Fortney, J. J.; et al.
-adsurl:  https://ui.adsabs.harvard.edu/abs/2011ApJ...729...32F
-{u.BOLD}bibcode{u.END}: 2011ApJ...729...32F
-
-Showing entries 5--6 out of 26 matches.  To show the next set, execute:
-bibm ads-search -n\n"""
+    expected_output = "\x1b[0m\x1b[?7h\x1b[0m\r\n\x1b[0;38;5;33mTitle\x1b[0m: \x1b[0;38;5;130mDiscovery and Atmospheric Characterization of Giant Planet Kepler-12b:\r\n    An Inflated Radius Outlier\x1b[0m\r\n\x1b[0;38;5;33mAuthors\x1b[0m: \x1b[0;38;5;130mFortney, Jonathan J.; et al.\x1b[0m\r\n\x1b[0;38;5;33mADS URL\x1b[0m: \x1b[0;38;5;130mhttps://ui.adsabs.harvard.edu/abs/2011ApJS..197....9F\x1b[0m\r\n\x1b[0;38;5;33mbibcode\x1b[0m: \x1b[0;38;5;142m2011ApJS..197....9F\x1b[0m\r\n\x1b[0m\x1b[0m\x1b[?7h\x1b[0m\r\n\x1b[0;38;5;33mTitle\x1b[0m: \x1b[0;38;5;130mSelf-consistent Model Atmospheres and the Cooling of the Solar System's\r\n    Giant Planets\x1b[0m\r\n\x1b[0;38;5;33mAuthors\x1b[0m: \x1b[0;38;5;130mFortney, J. J.; et al.\x1b[0m\r\n\x1b[0;38;5;33mADS URL\x1b[0m: \x1b[0;38;5;130mhttps://ui.adsabs.harvard.edu/abs/2011ApJ...729...32F\x1b[0m\r\n\x1b[0;38;5;33mbibcode\x1b[0m: \x1b[0;38;5;142m2011ApJ...729...32F\x1b[0m\r\n\x1b[0m\nShowing entries 5--6 out of 26 matches.  To show the next set, execute:\nbibm ads-search -n\n"
+    assert captured.out == expected_output

--- a/tests/test_bib_manager.py
+++ b/tests/test_bib_manager.py
@@ -423,17 +423,44 @@ def test_display_list_verb_zero(capfd, mock_init, mock_init_sample):
     bibs = [bibs[14], bibs[16]]
     bm.display_list(bibs, verb=0)
     captured = capfd.readouterr()
-    assert captured.out == """
-Title: Studies based on the colors and magnitudes in stellar clusters. VII.
-       The distances, distribution in space, and dimensions of 69 globular
-       clusters., 1918
-Authors: {Shapley}, H.
-key: Shapley1918apjDistanceGlobularClusters
+    # Trick to see how the screen output looks:
+    #print(repr(captured.out))
+    #print(captured.out)
+    expected_output = '\x1b[0m\x1b[?7h\x1b[0m\r\n\x1b[0;38;5;33mTitle\x1b[0m: \x1b[0;38;5;130mStudies based on the colors and magnitudes in stellar clusters. VII.\r\n    The distances, distribution in space, and dimensions of 69 globular\r\n    clusters., 1918\x1b[0m\r\n\x1b[0;38;5;33mAuthors\x1b[0m: \x1b[0;38;5;130m{Shapley}, H.\x1b[0m\r\n\x1b[0;38;5;33mkey\x1b[0m: \x1b[0;38;5;142mShapley1918apjDistanceGlobularClusters\x1b[0m\r\n\x1b[0m\x1b[0m\x1b[?7h\x1b[0m\r\n\x1b[0;38;5;33mTitle\x1b[0m: \x1b[0;38;5;130mThe radial velocity of the Andromeda Nebula, 1913\x1b[0m\r\n\x1b[0;38;5;33mAuthors\x1b[0m: \x1b[0;38;5;130m{Slipher}, V. M.\x1b[0m\r\n\x1b[0;38;5;33mkey\x1b[0m: \x1b[0;38;5;142mSlipher1913lobAndromedaRarialVelocity\x1b[0m\r\n\x1b[0m'
+    assert captured.out == expected_output
 
-Title: The radial velocity of the Andromeda Nebula, 1913
-Authors: {Slipher}, V. M.
-key: Slipher1913lobAndromedaRarialVelocity
-"""
+
+def test_display_list_no_author(capfd, mock_init, mock_init_sample):
+    bibs = bm.read_file(text='''@ARTICLE{Slipher1913lobAndromedaRarialVelocity,
+        title = "{The radial velocity of the Andromeda Nebula}",
+         year = 1913,
+}''')
+    bm.display_list(bibs, verb=0)
+    captured = capfd.readouterr()
+    expected_output = '\x1b[0m\x1b[?7h\x1b[0m\r\n\x1b[0;38;5;33mTitle\x1b[0m: \x1b[0;38;5;130mThe radial velocity of the Andromeda Nebula, 1913\x1b[0m\r\n\x1b[0;38;5;33mkey\x1b[0m: \x1b[0;38;5;142mSlipher1913lobAndromedaRarialVelocity\x1b[0m\r\n\x1b[0m'
+    assert captured.out == expected_output
+
+
+def test_display_list_no_year(capfd, mock_init, mock_init_sample):
+    bibs = bm.read_file(text='''@ARTICLE{Slipher1913lobAndromedaRarialVelocity,
+       author = {{Slipher}, V.~M.},
+        title = "{The radial velocity of the Andromeda Nebula}",
+}''')
+    bm.display_list(bibs, verb=0)
+    captured = capfd.readouterr()
+    expected_output = '\x1b[0m\x1b[?7h\x1b[0m\r\n\x1b[0;38;5;33mTitle\x1b[0m: \x1b[0;38;5;130mThe radial velocity of the Andromeda Nebula\x1b[0m\r\n\x1b[0;38;5;33mAuthors\x1b[0m: \x1b[0;38;5;130m{Slipher}, V. M.\x1b[0m\r\n\x1b[0;38;5;33mkey\x1b[0m: \x1b[0;38;5;142mSlipher1913lobAndromedaRarialVelocity\x1b[0m\r\n\x1b[0m'
+    assert captured.out == expected_output
+
+
+def test_display_list_no_title(capfd, mock_init, mock_init_sample):
+    bibs = bm.read_file(text='''@ARTICLE{Slipher1913lobAndromedaRarialVelocity,
+       author = {{Slipher}, V.~M.},
+         year = 1913,
+}''')
+    bm.display_list(bibs, verb=0)
+    captured = capfd.readouterr()
+    expected_output = '\x1b[0m\x1b[?7h\x1b[0m\r\n\x1b[0;38;5;33mTitle\x1b[0m: \x1b[0;38;5;130mNone, 1913\x1b[0m\r\n\x1b[0;38;5;33mAuthors\x1b[0m: \x1b[0;38;5;130m{Slipher}, V. M.\x1b[0m\r\n\x1b[0;38;5;33mkey\x1b[0m: \x1b[0;38;5;142mSlipher1913lobAndromedaRarialVelocity\x1b[0m\r\n\x1b[0m'
+    assert captured.out == expected_output
 
 
 def test_display_list_verb_one(capfd, mock_init, mock_init_sample):
@@ -441,36 +468,42 @@ def test_display_list_verb_one(capfd, mock_init, mock_init_sample):
     bibs = [bibs[14], bibs[16]]
     bm.display_list(bibs, verb=1)
     captured = capfd.readouterr()
-    assert captured.out == """
-Title: Studies based on the colors and magnitudes in stellar clusters. VII.
-       The distances, distribution in space, and dimensions of 69 globular
-       clusters., 1918
-Authors: {Shapley}, H.
-bibcode:   1918ApJ....48..154S
-ADS url:   http://adsabs.harvard.edu/abs/1918ApJ....48..154S
-key: Shapley1918apjDistanceGlobularClusters
-
-Title: The radial velocity of the Andromeda Nebula, 1913
-Authors: {Slipher}, V. M.
-bibcode:   1913LowOB...2...56S
-ADS url:   https://ui.adsabs.harvard.edu/abs/1913LowOB...2...56S
-PDF file:  Slipher1913.pdf
-key: Slipher1913lobAndromedaRarialVelocity
-"""
+    expected_output = '\x1b[0m\x1b[?7h\x1b[0m\r\n\x1b[0;38;5;33mTitle\x1b[0m: \x1b[0;38;5;130mStudies based on the colors and magnitudes in stellar clusters. VII.\r\n    The distances, distribution in space, and dimensions of 69 globular\r\n    clusters., 1918\x1b[0m\r\n\x1b[0;38;5;33mAuthors\x1b[0m: \x1b[0;38;5;130m{Shapley}, H.\x1b[0m\r\n\x1b[0;38;5;33mADS URL\x1b[0m: \x1b[0;38;5;130mhttp://adsabs.harvard.edu/abs/1918ApJ....48..154S\x1b[0m\r\n\x1b[0;38;5;33mbibcode\x1b[0m: \x1b[0;38;5;130m1918ApJ....48..154S\x1b[0m\r\n\x1b[0;38;5;33mkey\x1b[0m: \x1b[0;38;5;142mShapley1918apjDistanceGlobularClusters\x1b[0m\r\n\x1b[0m\x1b[0m\x1b[?7h\x1b[0m\r\n\x1b[0;38;5;33mTitle\x1b[0m: \x1b[0;38;5;130mThe radial velocity of the Andromeda Nebula, 1913\x1b[0m\r\n\x1b[0;38;5;33mAuthors\x1b[0m: \x1b[0;38;5;130m{Slipher}, V. M.\x1b[0m\r\n\x1b[0;38;5;33mADS URL\x1b[0m: \x1b[0;38;5;130mhttps://ui.adsabs.harvard.edu/abs/1913LowOB...2...56S\x1b[0m\r\n\x1b[0;38;5;33mbibcode\x1b[0m: \x1b[0;38;5;130m1913LowOB...2...56S\x1b[0m\r\n\x1b[0;38;5;33mPDF file\x1b[0m: \x1b[0;38;5;248;3mSlipher1913.pdf\x1b[0m\r\n\x1b[0;38;5;33mkey\x1b[0m: \x1b[0;38;5;142mSlipher1913lobAndromedaRarialVelocity\x1b[0m\r\n\x1b[0m'
+    assert captured.out == expected_output
 
 
 def test_display_list_verb_two(capfd, mock_init, mock_init_sample):
     bibs = bm.load()
     bm.display_list(bibs[3:4], verb=2)
     captured = capfd.readouterr()
-    assert captured.out == """
-Title: Synthesis of the Elements in Stars, 1957
-Authors: {Burbidge}, E. Margaret; {Burbidge}, G. R.; {Fowler}, William A.; and
-         {Hoyle}, F.
-bibcode:   1957RvMP...29..547B
-ADS url:   https://ui.adsabs.harvard.edu/abs/1957RvMP...29..547B
-key: BurbidgeEtal1957rvmpStellarElementSynthesis
-"""
+    expected_output = '\x1b[0m\x1b[?7h\x1b[0m\r\n\x1b[0;38;5;33mTitle\x1b[0m: \x1b[0;38;5;130mSynthesis of the Elements in Stars, 1957\x1b[0m\r\n\x1b[0;38;5;33mAuthors\x1b[0m: \x1b[0;38;5;130m{Burbidge}, E. Margaret; {Burbidge}, G. R.; {Fowler}, William A.; and\r\n    {Hoyle}, F.\x1b[0m\r\n\x1b[0;38;5;33mADS URL\x1b[0m: \x1b[0;38;5;130mhttps://ui.adsabs.harvard.edu/abs/1957RvMP...29..547B\x1b[0m\r\n\x1b[0;38;5;33mbibcode\x1b[0m: \x1b[0;38;5;130m1957RvMP...29..547B\x1b[0m\r\n\x1b[0;38;5;33mkey\x1b[0m: \x1b[0;38;5;142mBurbidgeEtal1957rvmpStellarElementSynthesis\x1b[0m\r\n\x1b[0m'
+    assert captured.out == expected_output
+
+
+def test_display_list_no_arxiv(capfd, mock_init, mock_init_sample):
+    bibs = bm.read_file(text='''@ARTICLE{Slipher1913lobAndromedaRarialVelocity,
+       author = {{Slipher}, V.~M.},
+        title = "{The radial velocity of the Andromeda Nebula}",
+         year = 1913,
+       adsurl = {https://ui.adsabs.harvard.edu/abs/1913LowOB...2...56S},
+}''')
+    bm.display_list(bibs, verb=1)
+    captured = capfd.readouterr()
+    expected_output = '\x1b[0m\x1b[?7h\x1b[0m\r\n\x1b[0;38;5;33mTitle\x1b[0m: \x1b[0;38;5;130mThe radial velocity of the Andromeda Nebula, 1913\x1b[0m\r\n\x1b[0;38;5;33mAuthors\x1b[0m: \x1b[0;38;5;130m{Slipher}, V. M.\x1b[0m\r\n\x1b[0;38;5;33mADS URL\x1b[0m: \x1b[0;38;5;130mhttps://ui.adsabs.harvard.edu/abs/1913LowOB...2...56S\x1b[0m\r\n\x1b[0;38;5;33mbibcode\x1b[0m: \x1b[0;38;5;130m1913LowOB...2...56S\x1b[0m\r\n\x1b[0;38;5;33mkey\x1b[0m: \x1b[0;38;5;142mSlipher1913lobAndromedaRarialVelocity\x1b[0m\r\n\x1b[0m'
+    assert captured.out == expected_output
+
+
+def test_display_list_no_ads(capfd, mock_init, mock_init_sample):
+    bibs = bm.read_file(text='''@ARTICLE{Slipher1913lobAndromedaRarialVelocity,
+       author = {{Slipher}, V.~M.},
+        title = "{The radial velocity of the Andromeda Nebula}",
+         year = 1913,
+       eprint = {0000.2000},
+}''')
+    bm.display_list(bibs, verb=1)
+    captured = capfd.readouterr()
+    expected_output = '\x1b[0m\x1b[?7h\x1b[0m\r\n\x1b[0;38;5;33mTitle\x1b[0m: \x1b[0;38;5;130mThe radial velocity of the Andromeda Nebula, 1913\x1b[0m\r\n\x1b[0;38;5;33mAuthors\x1b[0m: \x1b[0;38;5;130m{Slipher}, V. M.\x1b[0m\r\n\x1b[0;38;5;33mArXiv URL\x1b[0m: \x1b[0;38;5;130mhttp://arxiv.org/abs/0000.2000\x1b[0m\r\n\x1b[0;38;5;33mkey\x1b[0m: \x1b[0;38;5;142mSlipher1913lobAndromedaRarialVelocity\x1b[0m\r\n\x1b[0m'
+    assert captured.out == expected_output
 
 
 def test_display_list_verb_full(capfd, mock_init, mock_init_sample):

--- a/tests/test_bib_manager.py
+++ b/tests/test_bib_manager.py
@@ -23,8 +23,8 @@ def test_Bib_minimal(entries):
         u.Author(last='Jones', first='Eric', von='', jr=''),
         u.Author(last='Oliphant', first='Travis', von='', jr=''),
         u.Author(last='Peterson', first='Pearu', von='', jr='')]
-    assert bib.sort_author == u.Sort_author(last='jones', first='e',
-                                  von='', jr='', year=2001, month=13)
+    assert bib.sort_author == u.Sort_author(
+        last='jones', first='e', von='', jr='', year=2001, month=13)
     assert bib.year == 2001
     assert bib.title == "SciPy: Open source scientific tools for Python"
     assert bib.doi == None
@@ -64,8 +64,8 @@ def test_Bib_ads_entry(entries):
         u.Author(last='{Vidal-Madjar}', first='A.', von='', jr=''),
         u.Author(last='{Williamson}', first='M. H.', von='', jr=''),
         u.Author(last='{Wilson}', first='P. A.', von='', jr='')]
-    assert bib.sort_author == u.Sort_author(last='sing', first='dk', von='',
-                                  jr='', year=2016, month=1)
+    assert bib.sort_author == u.Sort_author(
+        last='sing', first='dk', von='', jr='', year=2016, month=1)
     assert bib.year == 2016
     assert bib.title == "A continuum from clear to cloudy hot-Jupiter exoplanets without primordial water depletion"
     assert bib.doi == "10.1038/nature16068"
@@ -394,6 +394,93 @@ def test_display_bibs_meta_shown(capfd, mock_init):
     assert captured.out == '\x1b[0m\x1b[?7h\x1b[0;38;5;248;3m\r\n::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::\r\n\x1b[0mDATABASE:\r\n\x1b[0;38;5;248;3m\x1b[0;38;5;34;1;4m@Misc\x1b[0m{\x1b[0;38;5;142mJonesEtal2001scipy\x1b[0m,\r\n       \x1b[0;38;5;33mauthor\x1b[0m = \x1b[0;38;5;130m{Eric Jones}\x1b[0m,\r\n       \x1b[0;38;5;33mtitle\x1b[0m  = \x1b[0;38;5;130m{SciPy}\x1b[0m,\r\n       \x1b[0;38;5;33myear\x1b[0m   = \x1b[0;38;5;130m{2001}\x1b[0m,\r\n    }\r\n\r\nNEW:\r\n\x1b[0;38;5;248;3mfreeze\r\npdf: file.pdf\r\n\x1b[0;38;5;34;1;4m@Misc\x1b[0m{\x1b[0;38;5;142mJones2001\x1b[0m,\r\n       \x1b[0;38;5;33mauthor\x1b[0m = \x1b[0;38;5;130m{Travis Oliphant}\x1b[0m,\r\n       \x1b[0;38;5;33mtitle\x1b[0m  = \x1b[0;38;5;130m{tools for Python}\x1b[0m,\r\n       \x1b[0;38;5;33myear\x1b[0m   = \x1b[0;38;5;130m{2001}\x1b[0m,\r\n    }\r\n\r\n\x1b[0m'
 
 
+def test_display_list_no_verb(capfd, mock_init, mock_init_sample):
+    bibs = bm.load()
+    bm.display_list(bibs[0:4])
+    captured = capfd.readouterr()
+    assert captured.out == (
+        'Keys:\n'
+        'AASteamHendrickson2018aastex62\n'
+        'Astropycollab2013aaAstropy\n'
+        'BeaulieuEtal2010arxivGJ436b\n'
+        'BurbidgeEtal1957rvmpStellarElementSynthesis\n')
+
+
+def test_display_list_verb_neg(capfd, mock_init, mock_init_sample):
+    bibs = bm.load()
+    bm.display_list(bibs[0:4], verb=-1)
+    captured = capfd.readouterr()
+    assert captured.out == (
+        'Keys:\n'
+        'AASteamHendrickson2018aastex62\n'
+        'Astropycollab2013aaAstropy\n'
+        'BeaulieuEtal2010arxivGJ436b\n'
+        'BurbidgeEtal1957rvmpStellarElementSynthesis\n')
+
+
+def test_display_list_verb_zero(capfd, mock_init, mock_init_sample):
+    bibs = bm.load()
+    bibs = [bibs[14], bibs[16]]
+    bm.display_list(bibs, verb=0)
+    captured = capfd.readouterr()
+    assert captured.out == """
+Title: Studies based on the colors and magnitudes in stellar clusters. VII.
+       The distances, distribution in space, and dimensions of 69 globular
+       clusters., 1918
+Authors: {Shapley}, H.
+key: Shapley1918apjDistanceGlobularClusters
+
+Title: The radial velocity of the Andromeda Nebula, 1913
+Authors: {Slipher}, V. M.
+key: Slipher1913lobAndromedaRarialVelocity
+"""
+
+
+def test_display_list_verb_one(capfd, mock_init, mock_init_sample):
+    bibs = bm.load()
+    bibs = [bibs[14], bibs[16]]
+    bm.display_list(bibs, verb=1)
+    captured = capfd.readouterr()
+    assert captured.out == """
+Title: Studies based on the colors and magnitudes in stellar clusters. VII.
+       The distances, distribution in space, and dimensions of 69 globular
+       clusters., 1918
+Authors: {Shapley}, H.
+bibcode:   1918ApJ....48..154S
+ADS url:   http://adsabs.harvard.edu/abs/1918ApJ....48..154S
+key: Shapley1918apjDistanceGlobularClusters
+
+Title: The radial velocity of the Andromeda Nebula, 1913
+Authors: {Slipher}, V. M.
+bibcode:   1913LowOB...2...56S
+ADS url:   https://ui.adsabs.harvard.edu/abs/1913LowOB...2...56S
+PDF file:  Slipher1913.pdf
+key: Slipher1913lobAndromedaRarialVelocity
+"""
+
+
+def test_display_list_verb_two(capfd, mock_init, mock_init_sample):
+    bibs = bm.load()
+    bm.display_list(bibs[3:4], verb=2)
+    captured = capfd.readouterr()
+    assert captured.out == """
+Title: Synthesis of the Elements in Stars, 1957
+Authors: {Burbidge}, E. Margaret; {Burbidge}, G. R.; {Fowler}, William A.; and
+         {Hoyle}, F.
+bibcode:   1957RvMP...29..547B
+ADS url:   https://ui.adsabs.harvard.edu/abs/1957RvMP...29..547B
+key: BurbidgeEtal1957rvmpStellarElementSynthesis
+"""
+
+
+def test_display_list_verb_full(capfd, mock_init, mock_init_sample):
+    bibs = bm.load()
+    bibs = [bibs[14], bibs[16]]
+    bm.display_list(bibs, verb=3)
+    captured = capfd.readouterr()
+    assert captured.out == '\x1b[0m\x1b[?7h\x1b[0;38;5;248;3m\r\n::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::\r\n\x1b[0m\x1b[0;38;5;248;3m\x1b[0;38;5;34;1;4m@ARTICLE\x1b[0m{\x1b[0;38;5;142mShapley1918apjDistanceGlobularClusters\x1b[0m,\r\n   \x1b[0;38;5;33mauthor\x1b[0m = \x1b[0;38;5;130m{{Shapley}, H.}\x1b[0m,\r\n    \x1b[0;38;5;33mtitle\x1b[0m = \x1b[0;38;5;130m"{Studies based on the colors and magnitudes in stellar clusters. VII. The distances, distribution in space, and dimensions of 69 globular clusters.}"\x1b[0m,\r\n  \x1b[0;38;5;33mjournal\x1b[0m = \x1b[0;38;5;130m{\\apj}\x1b[0m,\r\n     \x1b[0;38;5;33myear\x1b[0m = \x1b[0;38;5;30m1918\x1b[0m,\r\n    \x1b[0;38;5;33mmonth\x1b[0m = \x1b[0;38;5;124moct\x1b[0m,\r\n   \x1b[0;38;5;33mvolume\x1b[0m = \x1b[0;38;5;30m48\x1b[0m,\r\n      \x1b[0;38;5;33mdoi\x1b[0m = \x1b[0;38;5;130m{10.1086/142423}\x1b[0m,\r\n   \x1b[0;38;5;33madsurl\x1b[0m = \x1b[0;38;5;130m{http://adsabs.harvard.edu/abs/1918ApJ....48..154S}\x1b[0m,\r\n  \x1b[0;38;5;33madsnote\x1b[0m = \x1b[0;38;5;130m{Provided by the SAO/NASA Astrophysics Data System}\x1b[0m\r\n}\r\n\r\n\x1b[0;38;5;248;3mpdf: Slipher1913.pdf\r\n\x1b[0;38;5;34;1;4m@ARTICLE\x1b[0m{\x1b[0;38;5;142mSlipher1913lobAndromedaRarialVelocity\x1b[0m,\r\n       \x1b[0;38;5;33mauthor\x1b[0m = \x1b[0;38;5;130m{{Slipher}, V.~M.}\x1b[0m,\r\n        \x1b[0;38;5;33mtitle\x1b[0m = \x1b[0;38;5;130m"{The radial velocity of the Andromeda Nebula}"\x1b[0m,\r\n      \x1b[0;38;5;33mjournal\x1b[0m = \x1b[0;38;5;130m{Lowell Observatory Bulletin}\x1b[0m,\r\n     \x1b[0;38;5;33mkeywords\x1b[0m = \x1b[0;38;5;130m{GALAXIES: MOTION IN LINE OF SIGHT, ANDROMEDA GALAXY}\x1b[0m,\r\n         \x1b[0;38;5;33myear\x1b[0m = \x1b[0;38;5;30m1913\x1b[0m,\r\n        \x1b[0;38;5;33mmonth\x1b[0m = \x1b[0;38;5;124mJan\x1b[0m,\r\n       \x1b[0;38;5;33mvolume\x1b[0m = \x1b[0;38;5;130m{1}\x1b[0m,\r\n        \x1b[0;38;5;33mpages\x1b[0m = \x1b[0;38;5;130m{56-57}\x1b[0m,\r\n       \x1b[0;38;5;33madsurl\x1b[0m = \x1b[0;38;5;130m{https://ui.adsabs.harvard.edu/abs/1913LowOB...2...56S}\x1b[0m,\r\n      \x1b[0;38;5;33madsnote\x1b[0m = \x1b[0;38;5;130m{Provided by the SAO/NASA Astrophysics Data System}\x1b[0m\r\n}\r\n\r\n\x1b[0m'
+
+
 def test_remove_duplicates_no_duplicates(bibs):
     # No duplicates, no removal:
     my_bibs = [bibs['beaulieu_apj'], bibs['stodden']]
@@ -614,7 +701,7 @@ def test_find_key(mock_init_sample):
     key = 'AASteamHendrickson2018aastex62'
     bib = bm.find(key=key)
     assert bib is not None
-    assert bib.key == key 
+    assert bib.key == key
 
 
 def test_find_bibcode(mock_init_sample):
@@ -629,7 +716,7 @@ def test_find_key_bibcode(mock_init_sample):
     bibcode = '2013A&A...558A..33A'
     bib = bm.find(key=key, bibcode=bibcode)
     assert bib is not None
-    assert bib.key == key 
+    assert bib.key == key
     assert bib.bibcode != bibcode
 
 

--- a/tests/test_bib_manager.py
+++ b/tests/test_bib_manager.py
@@ -982,6 +982,16 @@ def test_search_key_multiple(mock_init_sample):
     assert 'BurbidgeEtal1957rvmpStellarElementSynthesis' in keys
 
 
+@pytest.mark.skip(reason='TBD')
+def test_search_single_tag():
+    pass
+
+
+@pytest.mark.skip(reason='TBD')
+def test_search_multiple_tags():
+    pass
+
+
 @pytest.mark.parametrize('mock_prompt_session',
      [['key: BurbidgeEtal1957rvmpStellarElementSynthesis']], indirect=True)
 def test_prompt_search_kw1(capsys, mock_init_sample, mock_prompt_session):

--- a/tests/test_bib_manager.py
+++ b/tests/test_bib_manager.py
@@ -399,7 +399,7 @@ def test_display_list_no_verb(capfd, mock_init, mock_init_sample):
     bm.display_list(bibs[0:4])
     captured = capfd.readouterr()
     assert captured.out == (
-        'Keys:\n'
+        '\nKeys:\n'
         'AASteamHendrickson2018aastex62\n'
         'Astropycollab2013aaAstropy\n'
         'BeaulieuEtal2010arxivGJ436b\n'
@@ -411,7 +411,7 @@ def test_display_list_verb_neg(capfd, mock_init, mock_init_sample):
     bm.display_list(bibs[0:4], verb=-1)
     captured = capfd.readouterr()
     assert captured.out == (
-        'Keys:\n'
+        '\nKeys:\n'
         'AASteamHendrickson2018aastex62\n'
         'Astropycollab2013aaAstropy\n'
         'BeaulieuEtal2010arxivGJ436b\n'

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -341,7 +341,19 @@ key: Shapley1918apjDistanceGlobularClusters\n"""
 
 @pytest.mark.parametrize('mock_prompt_session',
     [['author:"Burbidge, E"']], indirect=True)
-def test_cli_search_verbosity_zero(capsys, mock_init_sample,
+def test_cli_search_verbosity_negative(
+        capsys, mock_init_sample, mock_prompt_session):
+    sys.argv = "bibm search -v -1".split()
+    cli.main()
+    captured = capsys.readouterr()
+    assert captured.out == """(Press 'tab' for autocomplete)\n\n
+Keys:
+BurbidgeEtal1957rvmpStellarElementSynthesis\n"""
+
+
+@pytest.mark.parametrize('mock_prompt_session',
+    [['author:"Burbidge, E"']], indirect=True)
+def test_cli_search_verbosity_default_zero(capsys, mock_init_sample,
         mock_prompt_session):
     sys.argv = "bibm search".split()
     cli.main()
@@ -354,9 +366,40 @@ key: BurbidgeEtal1957rvmpStellarElementSynthesis\n"""
 
 @pytest.mark.parametrize('mock_prompt_session',
     [['author:"Burbidge, E"']], indirect=True)
+def test_cli_search_verbosity_explicitly_zero(
+        capsys, mock_init_sample, mock_prompt_session):
+    sys.argv = "bibm search -v 0".split()
+    cli.main()
+    captured = capsys.readouterr()
+    assert captured.out == """(Press 'tab' for autocomplete)\n\n
+Title: Synthesis of the Elements in Stars, 1957
+Authors: {Burbidge}, E. Margaret; et al.
+key: BurbidgeEtal1957rvmpStellarElementSynthesis\n"""
+
+
+@pytest.mark.parametrize('mock_prompt_session',
+    [['author:"Burbidge, E"']], indirect=True)
+def test_cli_search_verbosity_deprecated_one(
+        capsys, mock_init_sample, mock_prompt_session):
+    sys.argv = "bibm search -v".split()
+    cli.main()
+    captured = capsys.readouterr()
+    assert captured.out == """(Press 'tab' for autocomplete)\n
+Deprecation warning:
+The verbosity argument must be set to an integer value
+
+Title: Synthesis of the Elements in Stars, 1957
+Authors: {Burbidge}, E. Margaret; et al.
+bibcode:   1957RvMP...29..547B
+ADS url:   https://ui.adsabs.harvard.edu/abs/1957RvMP...29..547B
+key: BurbidgeEtal1957rvmpStellarElementSynthesis\n"""
+
+
+@pytest.mark.parametrize('mock_prompt_session',
+    [['author:"Burbidge, E"']], indirect=True)
 def test_cli_search_verbosity_one(capsys, mock_init_sample,
         mock_prompt_session):
-    sys.argv = "bibm search -v".split()
+    sys.argv = "bibm search -v 1".split()
     cli.main()
     captured = capsys.readouterr()
     assert captured.out == """(Press 'tab' for autocomplete)\n\n
@@ -371,7 +414,7 @@ key: BurbidgeEtal1957rvmpStellarElementSynthesis\n"""
     [['author:"Slipher, V"']], indirect=True)
 def test_cli_search_verbosity_meta(capsys, mock_init_sample,
         mock_prompt_session):
-    sys.argv = "bibm search -v".split()
+    sys.argv = "bibm search -v 1".split()
     cli.main()
     captured = capsys.readouterr()
     assert captured.out == """(Press 'tab' for autocomplete)\n\n
@@ -386,7 +429,7 @@ key: Slipher1913lobAndromedaRarialVelocity\n"""
 @pytest.mark.parametrize('mock_prompt_session',
     [['author:"Burbidge, E"']], indirect=True)
 def test_cli_search_verbosity_two(capsys, mock_init_sample,mock_prompt_session):
-    sys.argv = "bibm search -vv".split()
+    sys.argv = "bibm search -v 2".split()
     cli.main()
     captured = capsys.readouterr()
     assert captured.out == """(Press 'tab' for autocomplete)\n\n
@@ -402,7 +445,7 @@ key: BurbidgeEtal1957rvmpStellarElementSynthesis\n"""
     [['author:"Burbidge, E"']], indirect=True)
 def test_cli_search_verbosity_three(capfd, mock_init_sample,
         mock_prompt_session):
-    sys.argv = "bibm search -vvv".split()
+    sys.argv = "bibm search -v 3".split()
     cli.main()
     captured = capfd.readouterr()
     assert captured.out == '(Press \'tab\' for autocomplete)\n\n\x1b[0m\x1b[?7h\x1b[0;38;5;248;3m\r\n::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::\r\n\x1b[0m\x1b[0;38;5;248;3m\x1b[0;38;5;34;1;4m@ARTICLE\x1b[0m{\x1b[0;38;5;142mBurbidgeEtal1957rvmpStellarElementSynthesis\x1b[0m,\r\n       \x1b[0;38;5;33mauthor\x1b[0m = \x1b[0;38;5;130m{{Burbidge}, E. Margaret and {Burbidge}, G.~R. and {Fowler}, William A.\r\n        and {Hoyle}, F.}\x1b[0m,\r\n        \x1b[0;38;5;33mtitle\x1b[0m = \x1b[0;38;5;130m"{Synthesis of the Elements in Stars}"\x1b[0m,\r\n      \x1b[0;38;5;33mjournal\x1b[0m = \x1b[0;38;5;130m{Reviews of Modern Physics}\x1b[0m,\r\n         \x1b[0;38;5;33myear\x1b[0m = \x1b[0;38;5;30m1957\x1b[0m,\r\n        \x1b[0;38;5;33mmonth\x1b[0m = \x1b[0;38;5;124mJan\x1b[0m,\r\n       \x1b[0;38;5;33mvolume\x1b[0m = \x1b[0;38;5;130m{29}\x1b[0m,\r\n        \x1b[0;38;5;33mpages\x1b[0m = \x1b[0;38;5;130m{547-650}\x1b[0m,\r\n          \x1b[0;38;5;33mdoi\x1b[0m = \x1b[0;38;5;130m{10.1103/RevModPhys.29.547}\x1b[0m,\r\n       \x1b[0;38;5;33madsurl\x1b[0m = \x1b[0;38;5;130m{https://ui.adsabs.harvard.edu/abs/1957RvMP...29..547B}\x1b[0m,\r\n      \x1b[0;38;5;33madsnote\x1b[0m = \x1b[0;38;5;130m{Provided by the SAO/NASA Astrophysics Data System}\x1b[0m\r\n}\r\n\r\n\x1b[0m'

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -508,21 +508,8 @@ def test_cli_ads_search(capsys, reqs, mock_prompt_session, mock_init):
     captured = capsys.readouterr()
     cli.main()
     captured = capsys.readouterr()
-    assert captured.out == f"""(Press 'tab' for autocomplete)\n
-
-Title: A deeper look at Jupiter
-Authors: Fortney, Jonathan
-adsurl:  https://ui.adsabs.harvard.edu/abs/2018Natur.555..168F
-{u.BOLD}bibcode{u.END}: 2018Natur.555..168F
-
-Title: The Hunt for Planet Nine: Atmosphere, Spectra, Evolution, and
-       Detectability
-Authors: Fortney, Jonathan J.; et al.
-adsurl:  https://ui.adsabs.harvard.edu/abs/2016ApJ...824L..25F
-{u.BOLD}bibcode{u.END}: 2016ApJ...824L..25F
-
-Showing entries 1--2 out of 26 matches.  To show the next set, execute:
-bibm ads-search -n\n"""
+    expected_output = "(Press 'tab' for autocomplete)\n\n\x1b[0m\x1b[?7h\x1b[0m\r\n\x1b[0;38;5;33mTitle\x1b[0m: \x1b[0;38;5;130mA deeper look at Jupiter\x1b[0m\r\n\x1b[0;38;5;33mAuthors\x1b[0m: \x1b[0;38;5;130mFortney, Jonathan\x1b[0m\r\n\x1b[0;38;5;33mADS URL\x1b[0m: \x1b[0;38;5;130mhttps://ui.adsabs.harvard.edu/abs/2018Natur.555..168F\x1b[0m\r\n\x1b[0;38;5;33mbibcode\x1b[0m: \x1b[0;38;5;142m2018Natur.555..168F\x1b[0m\r\n\x1b[0m\x1b[0m\x1b[?7h\x1b[0m\r\n\x1b[0;38;5;33mTitle\x1b[0m: \x1b[0;38;5;130mThe Hunt for Planet Nine: Atmosphere, Spectra, Evolution, and\r\n    Detectability\x1b[0m\r\n\x1b[0;38;5;33mAuthors\x1b[0m: \x1b[0;38;5;130mFortney, Jonathan J.; et al.\x1b[0m\r\n\x1b[0;38;5;33mADS URL\x1b[0m: \x1b[0;38;5;130mhttps://ui.adsabs.harvard.edu/abs/2016ApJ...824L..25F\x1b[0m\r\n\x1b[0;38;5;33mbibcode\x1b[0m: \x1b[0;38;5;142m2016ApJ...824L..25F\x1b[0m\r\n\x1b[0m\nShowing entries 1--2 out of 26 matches.  To show the next set, execute:\nbibm ads-search -n\n"
+    assert captured.out == expected_output
 
 
 @pytest.mark.parametrize(
@@ -538,22 +525,8 @@ def test_cli_ads_search_next(capsys, reqs, mock_prompt_session, mock_init):
     sys.argv = "bibm ads-search -n".split()
     cli.main()
     captured = capsys.readouterr()
-    assert captured.out == f"""
-Title: A Framework for Characterizing the Atmospheres of Low-mass Low-density
-       Transiting Planets
-Authors: Fortney, Jonathan J.; et al.
-adsurl:  https://ui.adsabs.harvard.edu/abs/2013ApJ...775...80F
-{u.BOLD}bibcode{u.END}: 2013ApJ...775...80F
-
-Title: On the Carbon-to-oxygen Ratio Measurement in nearby Sun-like Stars:
-       Implications for Planet Formation and the Determination of Stellar
-       Abundances
-Authors: Fortney, Jonathan J.
-adsurl:  https://ui.adsabs.harvard.edu/abs/2012ApJ...747L..27F
-{u.BOLD}bibcode{u.END}: 2012ApJ...747L..27F
-
-Showing entries 3--4 out of 26 matches.  To show the next set, execute:
-bibm ads-search -n\n"""
+    expected_output = '\x1b[0m\x1b[?7h\x1b[0m\r\n\x1b[0;38;5;33mTitle\x1b[0m: \x1b[0;38;5;130mA Framework for Characterizing the Atmospheres of Low-mass Low-density\r\n    Transiting Planets\x1b[0m\r\n\x1b[0;38;5;33mAuthors\x1b[0m: \x1b[0;38;5;130mFortney, Jonathan J.; et al.\x1b[0m\r\n\x1b[0;38;5;33mADS URL\x1b[0m: \x1b[0;38;5;130mhttps://ui.adsabs.harvard.edu/abs/2013ApJ...775...80F\x1b[0m\r\n\x1b[0;38;5;33mbibcode\x1b[0m: \x1b[0;38;5;142m2013ApJ...775...80F\x1b[0m\r\n\x1b[0m\x1b[0m\x1b[?7h\x1b[0m\r\n\x1b[0;38;5;33mTitle\x1b[0m: \x1b[0;38;5;130mOn the Carbon-to-oxygen Ratio Measurement in nearby Sun-like Stars:\r\n    Implications for Planet Formation and the Determination of Stellar\r\n    Abundances\x1b[0m\r\n\x1b[0;38;5;33mAuthors\x1b[0m: \x1b[0;38;5;130mFortney, Jonathan J.\x1b[0m\r\n\x1b[0;38;5;33mADS URL\x1b[0m: \x1b[0;38;5;130mhttps://ui.adsabs.harvard.edu/abs/2012ApJ...747L..27F\x1b[0m\r\n\x1b[0;38;5;33mbibcode\x1b[0m: \x1b[0;38;5;142m2012ApJ...747L..27F\x1b[0m\r\n\x1b[0m\nShowing entries 3--4 out of 26 matches.  To show the next set, execute:\nbibm ads-search -n\n'
+    assert captured.out == expected_output
 
 
 @pytest.mark.parametrize('mock_prompt_session',
@@ -568,23 +541,9 @@ def test_cli_ads_search_empty_next(
     captured = capsys.readouterr()
     cli.main()
     captured = capsys.readouterr()
-    assert captured.out == f"""(Press 'tab' for autocomplete)\n
+    expected_output = "(Press 'tab' for autocomplete)\n\n\x1b[0m\x1b[?7h\x1b[0m\r\n\x1b[0;38;5;33mTitle\x1b[0m: \x1b[0;38;5;130mA Framework for Characterizing the Atmospheres of Low-mass Low-density\r\n    Transiting Planets\x1b[0m\r\n\x1b[0;38;5;33mAuthors\x1b[0m: \x1b[0;38;5;130mFortney, Jonathan J.; et al.\x1b[0m\r\n\x1b[0;38;5;33mADS URL\x1b[0m: \x1b[0;38;5;130mhttps://ui.adsabs.harvard.edu/abs/2013ApJ...775...80F\x1b[0m\r\n\x1b[0;38;5;33mbibcode\x1b[0m: \x1b[0;38;5;142m2013ApJ...775...80F\x1b[0m\r\n\x1b[0m\x1b[0m\x1b[?7h\x1b[0m\r\n\x1b[0;38;5;33mTitle\x1b[0m: \x1b[0;38;5;130mOn the Carbon-to-oxygen Ratio Measurement in nearby Sun-like Stars:\r\n    Implications for Planet Formation and the Determination of Stellar\r\n    Abundances\x1b[0m\r\n\x1b[0;38;5;33mAuthors\x1b[0m: \x1b[0;38;5;130mFortney, Jonathan J.\x1b[0m\r\n\x1b[0;38;5;33mADS URL\x1b[0m: \x1b[0;38;5;130mhttps://ui.adsabs.harvard.edu/abs/2012ApJ...747L..27F\x1b[0m\r\n\x1b[0;38;5;33mbibcode\x1b[0m: \x1b[0;38;5;142m2012ApJ...747L..27F\x1b[0m\r\n\x1b[0m\nShowing entries 3--4 out of 26 matches.  To show the next set, execute:\nbibm ads-search -n\n"
+    assert captured.out == expected_output
 
-Title: A Framework for Characterizing the Atmospheres of Low-mass Low-density
-       Transiting Planets
-Authors: Fortney, Jonathan J.; et al.
-adsurl:  https://ui.adsabs.harvard.edu/abs/2013ApJ...775...80F
-{u.BOLD}bibcode{u.END}: 2013ApJ...775...80F
-
-Title: On the Carbon-to-oxygen Ratio Measurement in nearby Sun-like Stars:
-       Implications for Planet Formation and the Determination of Stellar
-       Abundances
-Authors: Fortney, Jonathan J.
-adsurl:  https://ui.adsabs.harvard.edu/abs/2012ApJ...747L..27F
-{u.BOLD}bibcode{u.END}: 2012ApJ...747L..27F
-
-Showing entries 3--4 out of 26 matches.  To show the next set, execute:
-bibm ads-search -n\n"""
 
 @pytest.mark.parametrize('mock_prompt_session',
     [['', 'author:"^fortney, j" year:2000-2018 property:refereed']],

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -112,8 +112,9 @@ def test_cli_reset_keep_database(capsys, mock_init_sample):
     sys.argv = f"bibm reset {bibfile}".split()
     cli.main()
     captured = capsys.readouterr()
-    assert captured.out == f"Initializing new bibmanager database with BibTeX file: '{bibfile}'.\n" \
-                           "Resetting config parameters.\n"
+    assert captured.out == (
+        f"Initializing new bibmanager database with BibTeX file: '{bibfile}'.\n"
+        "Resetting config parameters.\n")
     assert set(os.listdir(u.HOME)) == set([
         "bm_database.pickle",
         "bm_bibliography.bib",
@@ -127,11 +128,11 @@ def test_cli_reset_keep_database(capsys, mock_init_sample):
 
 def test_cli_reset_error(capsys, mock_init):
     # Simulate user input:
-    sys.argv = f"bibm reset fake_file.bib".split()
+    sys.argv = "bibm reset fake_file.bib".split()
     cli.main()
     captured = capsys.readouterr()
-    assert captured.out \
-           == "\nError: Input BibTeX file 'fake_file.bib' does not exist.\n"
+    assert captured.out == \
+        "\nError: Input BibTeX file 'fake_file.bib' does not exist.\n"
 
 
 def test_cli_merge_default(capsys, mock_init):
@@ -140,17 +141,17 @@ def test_cli_merge_default(capsys, mock_init):
     sys.argv = f"bibm merge {bibfile}".split()
     cli.main()
     captured = capsys.readouterr()
-    assert captured.out  == f"\nMerged {nentries} new entries.\n\n" \
-                  f"Merged BibTeX file '{bibfile}' into bibmanager database.\n"
-
+    assert captured.out == (
+        f"\nMerged {nentries} new entries.\n\n"
+        f"Merged BibTeX file '{bibfile}' into bibmanager database.\n")
 
 def test_cli_merge_error(capsys, mock_init):
     # Simulate user input:
-    sys.argv = f"bibm merge fake_file.bib".split()
+    sys.argv = "bibm merge fake_file.bib".split()
     cli.main()
     captured = capsys.readouterr()
-    assert captured.out \
-           == "\nError: Input BibTeX file 'fake_file.bib' does not exist.\n"
+    assert captured.out == \
+        "\nError: Input BibTeX file 'fake_file.bib' does not exist.\n"
 
 
 # cli_edit() and cli_add() are direct calls (no need for testing).
@@ -184,8 +185,9 @@ def test_cli_search_year_invalid(capsys, mock_init_sample, mock_prompt_session):
     sys.argv = "bibm search".split()
     cli.main()
     captured = capsys.readouterr()
-    assert captured.out == ("(Press 'tab' for autocomplete)\n\n"
-                            "\nInvalid format for input year: 1984a\n")
+    assert captured.out == (
+        "(Press 'tab' for autocomplete)\n\n"
+        "\nInvalid format for input year: 1984a\n")
 
 @pytest.mark.parametrize('mock_prompt_session',
     [['author:"oliphant"'],
@@ -423,8 +425,9 @@ def test_cli_export_invalid_path(capsys, mock_init_sample):
     sys.argv = "bibm export invalid_path/my_file.bib".split()
     cli.main()
     captured = capsys.readouterr()
-    assert captured.out == "\nError: Output dir does not exists: " \
-                          f"'{os.path.realpath('invalid_path')}'\n"
+    assert captured.out == (
+        "\nError: Output dir does not exists: "
+        f"'{os.path.realpath('invalid_path')}'\n")
 
 
 def test_cli_export_invalid_bbl(capsys, mock_init_sample):
@@ -925,7 +928,7 @@ Saved PDF to: '1957RvMP...00..000B.pdf'.
      [['bibcode: 1957RvMP...29..547B'],
       ['key: BurbidgeEtal1957rvmpStellarElementSynthesis']], indirect=True)
 def test_cli_fetch_prompt(capsys, mock_init_sample, reqs, mock_prompt_session):
-    sys.argv = f"bibm fetch".split()
+    sys.argv = "bibm fetch".split()
     cli.main()
     captured = capsys.readouterr()
     assert captured.out == f"""Syntax is:  key: KEY_VALUE FILENAME
@@ -944,7 +947,7 @@ bibm open BurbidgeEtal1957rvmpStellarElementSynthesis\n"""
      indirect=True)
 def test_cli_fetch_prompt_key_filename(capsys, mock_init_sample, reqs,
         mock_prompt_session):
-    sys.argv = f"bibm fetch".split()
+    sys.argv = "bibm fetch".split()
     cli.main()
     captured = capsys.readouterr()
     assert captured.out == f"""Syntax is:  key: KEY_VALUE FILENAME
@@ -962,7 +965,7 @@ bibm open BurbidgeEtal1957rvmpStellarElementSynthesis\n"""
      [['bibcode: 1957RvMP...29..547B  Burbidge1957.pdf  extra']], indirect=True)
 def test_cli_fetch_prompt_ignore_extra(capsys, mock_init_sample, reqs,
         mock_prompt_session):
-    sys.argv = f"bibm fetch".split()
+    sys.argv = "bibm fetch".split()
     cli.main()
     captured = capsys.readouterr()
     assert captured.out == f"""Syntax is:  key: KEY_VALUE FILENAME
@@ -980,10 +983,10 @@ bibm open BurbidgeEtal1957rvmpStellarElementSynthesis\n"""
      [['']], indirect=True)
 def test_cli_fetch_prompt_bad_syntax(capsys, mock_init_sample, reqs,
         mock_prompt_session):
-    sys.argv = f"bibm fetch".split()
+    sys.argv = "bibm fetch".split()
     cli.main()
     captured = capsys.readouterr()
-    assert captured.out == f"""Syntax is:  key: KEY_VALUE FILENAME
+    assert captured.out == """Syntax is:  key: KEY_VALUE FILENAME
        or:  bibcode: BIBCODE_VALUE FILENAME
        (FILENAME is optional.  Press 'tab' for autocomplete)
 
@@ -995,10 +998,10 @@ Error: Invalid syntax.\n"""
      [['key: Burbidge1957']], indirect=True)
 def test_cli_fetch_prompt_invalid_bib(capsys, mock_init_sample, reqs,
         mock_prompt_session):
-    sys.argv = f"bibm fetch".split()
+    sys.argv = "bibm fetch".split()
     cli.main()
     captured = capsys.readouterr()
-    assert captured.out == f"""Syntax is:  key: KEY_VALUE FILENAME
+    assert captured.out == """Syntax is:  key: KEY_VALUE FILENAME
        or:  bibcode: BIBCODE_VALUE FILENAME
        (FILENAME is optional.  Press 'tab' for autocomplete)
 
@@ -1010,17 +1013,18 @@ Error: BibTex entry is not in Bibmanager database.\n"""
      [['key: AASteamHendrickson2018aastex62']], indirect=True)
 def test_cli_fetch_prompt_invalid_ads(capsys, mock_init_sample, reqs,
         mock_prompt_session):
-    sys.argv = f"bibm fetch AASteamHendrickson2018aastex62".split()
+    sys.argv = "bibm fetch AASteamHendrickson2018aastex62".split()
     cli.main()
     captured = capsys.readouterr()
-    assert captured.out == f"\nError: BibTex entry is not in ADS database.\n"
+    assert captured.out == "\nError: BibTex entry is not in ADS database.\n"
 
 
 def test_cli_fetch_pathed_filename(capsys, mock_init_sample, reqs):
     sys.argv = "bibm fetch 1957RvMP...29..547B ./new.pdf".split()
     cli.main()
     captured = capsys.readouterr()
-    assert captured.out == ("Fetching PDF file from Journal website:\n"
+    assert captured.out == (
+        "Fetching PDF file from Journal website:\n"
         "\nError: filename must not have a path\n")
 
 
@@ -1028,14 +1032,15 @@ def test_cli_fetch_invalid_name(capsys, mock_init_sample, reqs):
     sys.argv = "bibm fetch 1957RvMP...29..547B pdf_file".split()
     cli.main()
     captured = capsys.readouterr()
-    assert captured.out == ("Fetching PDF file from Journal website:\n"
+    assert captured.out == (
+        "Fetching PDF file from Journal website:\n"
         "\nError: Invalid filename, must have a .pdf extension\n")
 
 
 @pytest.mark.parametrize('keycode', [
-     'Slipher1913lobAndromedaRarialVelocity',
-     '1913LowOB...2...56S',
-     'Slipher1913.pdf'])
+    'Slipher1913lobAndromedaRarialVelocity',
+    '1913LowOB...2...56S',
+    'Slipher1913.pdf'])
 def test_cli_open_keycode(capsys, mock_init_sample, mock_call, mock_open,
         keycode):
     pathlib.Path(f"{u.BM_PDF()}Slipher1913.pdf").touch()
@@ -1047,10 +1052,11 @@ def test_cli_open_keycode(capsys, mock_init_sample, mock_call, mock_open,
 
 def test_cli_open_keycode_invalid(capsys, mock_init_sample, mock_call):
     pathlib.Path(f"{u.BM_PDF()}Slipher1913.pdf").touch()
-    sys.argv = f"bibm open bad_keycode".split()
+    sys.argv = "bibm open bad_keycode".split()
     cli.main()
     captured = capsys.readouterr()
-    assert captured.out == ('\nError: Input is no key, bibcode, or PDF '
+    assert captured.out == (
+        '\nError: Input is no key, bibcode, or PDF '
         'of any entry in Bibmanager database\n')
 
 
@@ -1061,10 +1067,11 @@ def test_cli_open_keycode_invalid(capsys, mock_init_sample, mock_call):
 def test_cli_open_prompt(capsys, mock_init_sample, mock_call, mock_open,
         mock_prompt_session):
     pathlib.Path(f"{u.BM_PDF()}Slipher1913.pdf").touch()
-    sys.argv = f"bibm open".split()
+    sys.argv = "bibm open".split()
     cli.main()
     captured = capsys.readouterr()
-    assert captured.out == ("Syntax is:  key: KEY_VALUE\n"
+    assert captured.out == (
+        "Syntax is:  key: KEY_VALUE\n"
         "       or:  bibcode: BIBCODE_VALUE\n"
         "       or:  pdf: PDF_VALUE\n"
         "(Press 'tab' for autocomplete)\n\n")
@@ -1075,10 +1082,11 @@ def test_cli_open_prompt(capsys, mock_init_sample, mock_call, mock_open,
 def test_cli_open_prompt_error(capsys, mock_init_sample, mock_call,
         mock_prompt_session):
     pathlib.Path(f"{u.BM_PDF()}Slipher1913.pdf").touch()
-    sys.argv = f"bibm open".split()
+    sys.argv = "bibm open".split()
     cli.main()
     captured = capsys.readouterr()
-    assert captured.out == ("Syntax is:  key: KEY_VALUE\n"
+    assert captured.out == (
+        "Syntax is:  key: KEY_VALUE\n"
         "       or:  bibcode: BIBCODE_VALUE\n"
         "       or:  pdf: PDF_VALUE\n"
         "(Press 'tab' for autocomplete)\n\n\n"
@@ -1087,7 +1095,7 @@ def test_cli_open_prompt_error(capsys, mock_init_sample, mock_call,
 
 @pytest.mark.parametrize('mock_input', [['yes']], indirect=True)
 def test_cli_open_fetch(capsys, mock_init_sample, mock_call, reqs, mock_input):
-    sys.argv = f"bibm open 1957RvMP...29..547B".split()
+    sys.argv = "bibm open 1957RvMP...29..547B".split()
     cli.main()
     captured = capsys.readouterr()
     assert captured.out == (
@@ -1102,7 +1110,7 @@ def test_cli_open_fetch(capsys, mock_init_sample, mock_call, reqs, mock_input):
     ['1957RvMP...29..547B', 'BurbidgeEtal1957rvmpStellarElementSynthesis'])
 def test_cli_pdf_set_keycode(capsys, mock_init_sample, mock_call, keycode):
     sys.argv = f"bibm pdf {keycode} file.pdf".split()
-    pathlib.Path(f"file.pdf").touch()
+    pathlib.Path("file.pdf").touch()
     cli.main()
     captured = capsys.readouterr()
     assert captured.out == f"Saved PDF to: '{u.BM_PDF()}file.pdf'.\n"
@@ -1112,8 +1120,8 @@ def test_cli_pdf_set_keycode(capsys, mock_init_sample, mock_call, keycode):
 
 
 def test_cli_pdf_set_renamed(capsys, mock_init_sample, mock_call):
-    sys.argv = f"bibm pdf 1957RvMP...29..547B file.pdf new.pdf".split()
-    pathlib.Path(f"file.pdf").touch()
+    sys.argv = "bibm pdf 1957RvMP...29..547B file.pdf new.pdf".split()
+    pathlib.Path("file.pdf").touch()
     cli.main()
     captured = capsys.readouterr()
     assert captured.out == f"Saved PDF to: '{u.BM_PDF()}new.pdf'.\n"
@@ -1123,8 +1131,8 @@ def test_cli_pdf_set_renamed(capsys, mock_init_sample, mock_call):
 
 
 def test_cli_pdf_set_guessed(capsys, mock_init_sample, mock_call):
-    sys.argv = f"bibm pdf 1957RvMP...29..547B file.pdf guess".split()
-    pathlib.Path(f"file.pdf").touch()
+    sys.argv = "bibm pdf 1957RvMP...29..547B file.pdf guess".split()
+    pathlib.Path("file.pdf").touch()
     cli.main()
     captured = capsys.readouterr()
     assert captured.out == \
@@ -1135,12 +1143,12 @@ def test_cli_pdf_set_guessed(capsys, mock_init_sample, mock_call):
 
 
 @pytest.mark.parametrize('mock_prompt_session',
-    [[f'key: BurbidgeEtal1957rvmpStellarElementSynthesis file.pdf']],
+    [['key: BurbidgeEtal1957rvmpStellarElementSynthesis file.pdf']],
     indirect=True)
 def test_cli_pdf_set_prompt_key(capsys, mock_init_sample, mock_call,
         mock_prompt_session):
-    sys.argv = f"bibm pdf".split()
-    pathlib.Path(f"file.pdf").touch()
+    sys.argv = "bibm pdf".split()
+    pathlib.Path("file.pdf").touch()
     cli.main()
     captured = capsys.readouterr()
     assert captured.out == (
@@ -1154,11 +1162,11 @@ def test_cli_pdf_set_prompt_key(capsys, mock_init_sample, mock_call,
 
 
 @pytest.mark.parametrize('mock_prompt_session',
-    [[f'bibcode: 1957RvMP...29..547B file.pdf']], indirect=True)
+    [['bibcode: 1957RvMP...29..547B file.pdf']], indirect=True)
 def test_cli_pdf_set_prompt_bibcode(capsys, mock_init_sample, mock_call,
         mock_prompt_session):
-    sys.argv = f"bibm pdf".split()
-    pathlib.Path(f"file.pdf").touch()
+    sys.argv = "bibm pdf".split()
+    pathlib.Path("file.pdf").touch()
     cli.main()
     captured = capsys.readouterr()
     assert captured.out == (
@@ -1172,11 +1180,11 @@ def test_cli_pdf_set_prompt_bibcode(capsys, mock_init_sample, mock_call,
 
 
 @pytest.mark.parametrize('mock_prompt_session',
-    [[f'bibcode: 1957RvMP...29..547B file.pdf new.pdf']], indirect=True)
+    [['bibcode: 1957RvMP...29..547B file.pdf new.pdf']], indirect=True)
 def test_cli_pdf_set_prompt_rename(capsys, mock_init_sample, mock_call,
         mock_prompt_session):
-    sys.argv = f"bibm pdf".split()
-    pathlib.Path(f"file.pdf").touch()
+    sys.argv = "bibm pdf".split()
+    pathlib.Path("file.pdf").touch()
     cli.main()
     captured = capsys.readouterr()
     assert captured.out == (
@@ -1190,11 +1198,11 @@ def test_cli_pdf_set_prompt_rename(capsys, mock_init_sample, mock_call,
 
 
 @pytest.mark.parametrize('mock_prompt_session',
-    [[f'bibcode: 1957RvMP...29..547B file.pdf guess']], indirect=True)
+    [['bibcode: 1957RvMP...29..547B file.pdf guess']], indirect=True)
 def test_cli_pdf_set_prompt_guess(capsys, mock_init_sample, mock_call,
         mock_prompt_session):
-    sys.argv = f"bibm pdf".split()
-    pathlib.Path(f"file.pdf").touch()
+    sys.argv = "bibm pdf".split()
+    pathlib.Path("file.pdf").touch()
     cli.main()
     captured = capsys.readouterr()
     assert captured.out == (
@@ -1208,8 +1216,8 @@ def test_cli_pdf_set_prompt_guess(capsys, mock_init_sample, mock_call,
 
 
 def test_cli_pdf_set_missing_pdf(capsys, mock_init_sample):
-    sys.argv = f"bibm pdf 1957RvMP...29..547B".split()
-    pathlib.Path(f"file.pdf").touch()
+    sys.argv = "bibm pdf 1957RvMP...29..547B".split()
+    pathlib.Path("file.pdf").touch()
     cli.main()
     captured = capsys.readouterr()
     assert captured.out == "\nError: Path to PDF file is missing.\n"
@@ -1219,7 +1227,7 @@ def test_cli_pdf_set_missing_pdf(capsys, mock_init_sample):
 
 
 def test_cli_pdf_set_missing_bib(capsys, mock_init_sample):
-    sys.argv = f"bibm pdf 1957RvMP...00..000X file.pdf".split()
+    sys.argv = "bibm pdf 1957RvMP...00..000X file.pdf".split()
     pathlib.Path("file.pdf").touch()
     cli.main()
     captured = capsys.readouterr()
@@ -1265,11 +1273,11 @@ def test_cli_pdf_set_invalid_name(capsys, mock_init_sample):
 
 
 @pytest.mark.parametrize('mock_prompt_session',
-    [[f'bibcode: 1957RvMP...29..547B']], indirect=True)
+    [['bibcode: 1957RvMP...29..547B']], indirect=True)
 def test_cli_pdf_set_prompt_missing_pdf(capsys, mock_init_sample,
         mock_prompt_session):
-    sys.argv = f"bibm pdf".split()
-    pathlib.Path(f"file.pdf").touch()
+    sys.argv = "bibm pdf".split()
+    pathlib.Path("file.pdf").touch()
     cli.main()
     captured = capsys.readouterr()
     assert captured.out == (
@@ -1311,7 +1319,7 @@ def test_cli_future_pickle(capsys, mock_init_sample):
     sys.argv = "bibm reset".split()
     cli.main()
     captured = capsys.readouterr()
-    assert captured.out == \
-       (f"Bibmanager version ({bibmanager.__version__}) is older than "
+    assert captured.out == (
+        f"Bibmanager version ({bibmanager.__version__}) is older than "
         f"saved database.  Please update to a version >= {future_version}.\n")
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -36,6 +36,8 @@ Use one line for each BibTeX entry, separate fields with blank spaces.
 
 """
 
+expected_numpy = "(Press 'tab' for autocomplete)\n\n\x1b[0m\x1b[?7h\x1b[0m\r\n\x1b[0;38;5;33mTitle\x1b[0m: \x1b[0;38;5;130mNumpy: A guide to NumPy, 2006\x1b[0m\r\n\x1b[0;38;5;33mAuthors\x1b[0m: \x1b[0;38;5;130mOliphant, Travis\x1b[0m\r\n\x1b[0;38;5;33mkey\x1b[0m: \x1b[0;38;5;142mOliphant2006numpy\x1b[0m\r\n\x1b[0m"
+
 
 def test_cli_version(capsys):
     sys.argv = "bibm --version".split()
@@ -196,14 +198,8 @@ def test_cli_search_author(capsys, mock_init_sample, mock_prompt_session):
     sys.argv = "bibm search".split()
     cli.main()
     captured = capsys.readouterr()
-    assert captured.out == """(Press 'tab' for autocomplete)\n\n
-Title: SciPy: Open source scientific tools for Python, 2001
-Authors: Jones, Eric; et al.
-key: JonesEtal2001scipy
-
-Title: Numpy: A guide to NumPy, 2006
-Authors: Oliphant, Travis
-key: Oliphant2006numpy\n"""
+    expected_output = "(Press 'tab' for autocomplete)\n\n\x1b[0m\x1b[?7h\x1b[0m\r\n\x1b[0;38;5;33mTitle\x1b[0m: \x1b[0;38;5;130mSciPy: Open source scientific tools for Python, 2001\x1b[0m\r\n\x1b[0;38;5;33mAuthors\x1b[0m: \x1b[0;38;5;130mJones, Eric; et al.\x1b[0m\r\n\x1b[0;38;5;33mkey\x1b[0m: \x1b[0;38;5;142mJonesEtal2001scipy\x1b[0m\r\n\x1b[0m\x1b[0m\x1b[?7h\x1b[0m\r\n\x1b[0;38;5;33mTitle\x1b[0m: \x1b[0;38;5;130mNumpy: A guide to NumPy, 2006\x1b[0m\r\n\x1b[0;38;5;33mAuthors\x1b[0m: \x1b[0;38;5;130mOliphant, Travis\x1b[0m\r\n\x1b[0;38;5;33mkey\x1b[0m: \x1b[0;38;5;142mOliphant2006numpy\x1b[0m\r\n\x1b[0m"
+    assert captured.out == expected_output
 
 
 @pytest.mark.parametrize('mock_prompt_session',
@@ -213,23 +209,19 @@ def test_cli_search_first_author(capsys, mock_init_sample, mock_prompt_session):
     sys.argv = "bibm search".split()
     cli.main()
     captured = capsys.readouterr()
-    assert captured.out == """(Press 'tab' for autocomplete)\n\n
-Title: Numpy: A guide to NumPy, 2006
-Authors: Oliphant, Travis
-key: Oliphant2006numpy\n"""
+    expected_output = expected_numpy
+    assert captured.out == expected_output
 
 
 @pytest.mark.parametrize('mock_prompt_session',
     [['author:"oliphant" author:"jones, e"']], indirect=True)
-def test_cli_search_multiple_authors(capsys, mock_init_sample,
-        mock_prompt_session):
+def test_cli_search_multiple_authors(
+        capsys, mock_init_sample, mock_prompt_session):
     sys.argv = "bibm search".split()
     cli.main()
     captured = capsys.readouterr()
-    assert captured.out == """(Press 'tab' for autocomplete)\n\n
-Title: SciPy: Open source scientific tools for Python, 2001
-Authors: Jones, Eric; et al.
-key: JonesEtal2001scipy\n"""
+    expected_output = "(Press 'tab' for autocomplete)\n\n\x1b[0m\x1b[?7h\x1b[0m\r\n\x1b[0;38;5;33mTitle\x1b[0m: \x1b[0;38;5;130mSciPy: Open source scientific tools for Python, 2001\x1b[0m\r\n\x1b[0;38;5;33mAuthors\x1b[0m: \x1b[0;38;5;130mJones, Eric; et al.\x1b[0m\r\n\x1b[0;38;5;33mkey\x1b[0m: \x1b[0;38;5;142mJonesEtal2001scipy\x1b[0m\r\n\x1b[0m"
+    assert captured.out == expected_output
 
 
 @pytest.mark.parametrize('mock_prompt_session',
@@ -238,10 +230,7 @@ def test_cli_search_author_year(capsys, mock_init_sample, mock_prompt_session):
     sys.argv = "bibm search".split()
     cli.main()
     captured = capsys.readouterr()
-    assert captured.out == """(Press 'tab' for autocomplete)\n\n
-Title: Numpy: A guide to NumPy, 2006
-Authors: Oliphant, Travis
-key: Oliphant2006numpy\n"""
+    assert captured.out == expected_numpy
 
 
 @pytest.mark.parametrize('mock_prompt_session',
@@ -251,10 +240,7 @@ def test_cli_search_author_year_ignore_second_year(capsys, mock_init_sample,
     sys.argv = "bibm search".split()
     cli.main()
     captured = capsys.readouterr()
-    assert captured.out == """(Press 'tab' for autocomplete)\n\n
-Title: Numpy: A guide to NumPy, 2006
-Authors: Oliphant, Travis
-key: Oliphant2006numpy\n"""
+    assert captured.out == expected_numpy
 
 
 @pytest.mark.parametrize('mock_prompt_session',
@@ -264,12 +250,8 @@ def test_cli_search_multiple_title_kws(capsys, mock_init_sample,
     sys.argv = "bibm search".split()
     cli.main()
     captured = capsys.readouterr()
-    assert captured.out == """(Press 'tab' for autocomplete)\n\n
-Title: Atmospheric Circulation of Hot Jupiters: Coupled Radiative-Dynamical
-       General Circulation Model Simulations of HD 189733b and HD 209458b,
-       2009
-Authors: {Showman}, Adam P.; et al.
-key: ShowmanEtal2009apjRadGCM\n"""
+    expected_output = "(Press 'tab' for autocomplete)\n\n\x1b[0m\x1b[?7h\x1b[0m\r\n\x1b[0;38;5;33mTitle\x1b[0m: \x1b[0;38;5;130mAtmospheric Circulation of Hot Jupiters: Coupled Radiative-Dynamical\r\n    General Circulation Model Simulations of HD 189733b and HD 209458b, 2009\x1b[0m\r\n\x1b[0;38;5;33mAuthors\x1b[0m: \x1b[0;38;5;130m{Showman}, Adam P.; et al.\x1b[0m\r\n\x1b[0;38;5;33mkey\x1b[0m: \x1b[0;38;5;142mShowmanEtal2009apjRadGCM\x1b[0m\r\n\x1b[0m"
+    assert captured.out == expected_output
 
 
 @pytest.mark.parametrize('mock_prompt_session',
@@ -279,10 +261,8 @@ def test_cli_search_bibcode(capsys, mock_init_sample, mock_prompt_session):
     sys.argv = "bibm search".split()
     cli.main()
     captured = capsys.readouterr()
-    assert captured.out == """(Press 'tab' for autocomplete)\n\n
-Title: Astropy: A community Python package for astronomy, 2013
-Authors: {Astropy Collaboration}; et al.
-key: Astropycollab2013aaAstropy\n"""
+    expected_output = "(Press 'tab' for autocomplete)\n\n\x1b[0m\x1b[?7h\x1b[0m\r\n\x1b[0;38;5;33mTitle\x1b[0m: \x1b[0;38;5;130mAstropy: A community Python package for astronomy, 2013\x1b[0m\r\n\x1b[0;38;5;33mAuthors\x1b[0m: \x1b[0;38;5;130m{Astropy Collaboration}; et al.\x1b[0m\r\n\x1b[0;38;5;33mkey\x1b[0m: \x1b[0;38;5;142mAstropycollab2013aaAstropy\x1b[0m\r\n\x1b[0m"
+    assert captured.out == expected_output
 
 
 @pytest.mark.parametrize('mock_prompt_session',
@@ -293,30 +273,17 @@ def test_cli_search_multiple_bibcodes(capsys, mock_init_sample,
     sys.argv = "bibm search".split()
     cli.main()
     captured = capsys.readouterr()
-    assert captured.out == """(Press 'tab' for autocomplete)\n\n
-Title: Novae in the Spiral Nebulae and the Island Universe Theory, 1917
-Authors: {Curtis}, H. D.
-key: Curtis1917paspIslandUniverseTheory
-
-Title: Studies based on the colors and magnitudes in stellar clusters. VII.
-       The distances, distribution in space, and dimensions of 69 globular
-       clusters., 1918
-Authors: {Shapley}, H.
-key: Shapley1918apjDistanceGlobularClusters\n"""
+    expected_output = "(Press 'tab' for autocomplete)\n\n\x1b[0m\x1b[?7h\x1b[0m\r\n\x1b[0;38;5;33mTitle\x1b[0m: \x1b[0;38;5;130mNovae in the Spiral Nebulae and the Island Universe Theory, 1917\x1b[0m\r\n\x1b[0;38;5;33mAuthors\x1b[0m: \x1b[0;38;5;130m{Curtis}, H. D.\x1b[0m\r\n\x1b[0;38;5;33mkey\x1b[0m: \x1b[0;38;5;142mCurtis1917paspIslandUniverseTheory\x1b[0m\r\n\x1b[0m\x1b[0m\x1b[?7h\x1b[0m\r\n\x1b[0;38;5;33mTitle\x1b[0m: \x1b[0;38;5;130mStudies based on the colors and magnitudes in stellar clusters. VII.\r\n    The distances, distribution in space, and dimensions of 69 globular\r\n    clusters., 1918\x1b[0m\r\n\x1b[0;38;5;33mAuthors\x1b[0m: \x1b[0;38;5;130m{Shapley}, H.\x1b[0m\r\n\x1b[0;38;5;33mkey\x1b[0m: \x1b[0;38;5;142mShapley1918apjDistanceGlobularClusters\x1b[0m\r\n\x1b[0m"
+    assert captured.out == expected_output
 
 
 @pytest.mark.parametrize('mock_prompt_session',
-    [['key:Shapley1918apjDistanceGlobularClusters']], indirect=True)
+    [['key:Oliphant2006numpy']], indirect=True)
 def test_cli_search_key(capsys, mock_init_sample, mock_prompt_session):
     sys.argv = "bibm search".split()
     cli.main()
     captured = capsys.readouterr()
-    assert captured.out == """(Press 'tab' for autocomplete)\n\n
-Title: Studies based on the colors and magnitudes in stellar clusters. VII.
-       The distances, distribution in space, and dimensions of 69 globular
-       clusters., 1918
-Authors: {Shapley}, H.
-key: Shapley1918apjDistanceGlobularClusters\n"""
+    assert captured.out == expected_numpy
 
 
 @pytest.mark.parametrize('mock_prompt_session',
@@ -327,16 +294,8 @@ def test_cli_search_multiple_keys(capsys, mock_init_sample,
     sys.argv = "bibm search".split()
     cli.main()
     captured = capsys.readouterr()
-    assert captured.out == """(Press 'tab' for autocomplete)\n\n
-Title: Novae in the Spiral Nebulae and the Island Universe Theory, 1917
-Authors: {Curtis}, H. D.
-key: Curtis1917paspIslandUniverseTheory
-
-Title: Studies based on the colors and magnitudes in stellar clusters. VII.
-       The distances, distribution in space, and dimensions of 69 globular
-       clusters., 1918
-Authors: {Shapley}, H.
-key: Shapley1918apjDistanceGlobularClusters\n"""
+    expected_output = "(Press 'tab' for autocomplete)\n\n\x1b[0m\x1b[?7h\x1b[0m\r\n\x1b[0;38;5;33mTitle\x1b[0m: \x1b[0;38;5;130mNovae in the Spiral Nebulae and the Island Universe Theory, 1917\x1b[0m\r\n\x1b[0;38;5;33mAuthors\x1b[0m: \x1b[0;38;5;130m{Curtis}, H. D.\x1b[0m\r\n\x1b[0;38;5;33mkey\x1b[0m: \x1b[0;38;5;142mCurtis1917paspIslandUniverseTheory\x1b[0m\r\n\x1b[0m\x1b[0m\x1b[?7h\x1b[0m\r\n\x1b[0;38;5;33mTitle\x1b[0m: \x1b[0;38;5;130mStudies based on the colors and magnitudes in stellar clusters. VII.\r\n    The distances, distribution in space, and dimensions of 69 globular\r\n    clusters., 1918\x1b[0m\r\n\x1b[0;38;5;33mAuthors\x1b[0m: \x1b[0;38;5;130m{Shapley}, H.\x1b[0m\r\n\x1b[0;38;5;33mkey\x1b[0m: \x1b[0;38;5;142mShapley1918apjDistanceGlobularClusters\x1b[0m\r\n\x1b[0m"
+    assert captured.out == expected_output
 
 
 @pytest.mark.parametrize('mock_prompt_session',
@@ -358,10 +317,8 @@ def test_cli_search_verbosity_default_zero(capsys, mock_init_sample,
     sys.argv = "bibm search".split()
     cli.main()
     captured = capsys.readouterr()
-    assert captured.out == """(Press 'tab' for autocomplete)\n\n
-Title: Synthesis of the Elements in Stars, 1957
-Authors: {Burbidge}, E. Margaret; et al.
-key: BurbidgeEtal1957rvmpStellarElementSynthesis\n"""
+    expected_output = "(Press 'tab' for autocomplete)\n\n\x1b[0m\x1b[?7h\x1b[0m\r\n\x1b[0;38;5;33mTitle\x1b[0m: \x1b[0;38;5;130mSynthesis of the Elements in Stars, 1957\x1b[0m\r\n\x1b[0;38;5;33mAuthors\x1b[0m: \x1b[0;38;5;130m{Burbidge}, E. Margaret; et al.\x1b[0m\r\n\x1b[0;38;5;33mkey\x1b[0m: \x1b[0;38;5;142mBurbidgeEtal1957rvmpStellarElementSynthesis\x1b[0m\r\n\x1b[0m"
+    assert captured.out == expected_output
 
 
 @pytest.mark.parametrize('mock_prompt_session',
@@ -371,10 +328,8 @@ def test_cli_search_verbosity_explicitly_zero(
     sys.argv = "bibm search -v 0".split()
     cli.main()
     captured = capsys.readouterr()
-    assert captured.out == """(Press 'tab' for autocomplete)\n\n
-Title: Synthesis of the Elements in Stars, 1957
-Authors: {Burbidge}, E. Margaret; et al.
-key: BurbidgeEtal1957rvmpStellarElementSynthesis\n"""
+    expected_output = "(Press 'tab' for autocomplete)\n\n\x1b[0m\x1b[?7h\x1b[0m\r\n\x1b[0;38;5;33mTitle\x1b[0m: \x1b[0;38;5;130mSynthesis of the Elements in Stars, 1957\x1b[0m\r\n\x1b[0;38;5;33mAuthors\x1b[0m: \x1b[0;38;5;130m{Burbidge}, E. Margaret; et al.\x1b[0m\r\n\x1b[0;38;5;33mkey\x1b[0m: \x1b[0;38;5;142mBurbidgeEtal1957rvmpStellarElementSynthesis\x1b[0m\r\n\x1b[0m"
+    assert captured.out == expected_output
 
 
 @pytest.mark.parametrize('mock_prompt_session',
@@ -384,46 +339,30 @@ def test_cli_search_verbosity_deprecated_one(
     sys.argv = "bibm search -v".split()
     cli.main()
     captured = capsys.readouterr()
-    assert captured.out == """(Press 'tab' for autocomplete)\n
-Deprecation warning:
-The verbosity argument must be set to an integer value
-
-Title: Synthesis of the Elements in Stars, 1957
-Authors: {Burbidge}, E. Margaret; et al.
-bibcode:   1957RvMP...29..547B
-ADS url:   https://ui.adsabs.harvard.edu/abs/1957RvMP...29..547B
-key: BurbidgeEtal1957rvmpStellarElementSynthesis\n"""
+    expected_output = "(Press 'tab' for autocomplete)\n\nDeprecation warning:\nThe verbosity argument must be set to an integer value\n\x1b[0m\x1b[?7h\x1b[0m\r\n\x1b[0;38;5;33mTitle\x1b[0m: \x1b[0;38;5;130mSynthesis of the Elements in Stars, 1957\x1b[0m\r\n\x1b[0;38;5;33mAuthors\x1b[0m: \x1b[0;38;5;130m{Burbidge}, E. Margaret; et al.\x1b[0m\r\n\x1b[0;38;5;33mADS URL\x1b[0m: \x1b[0;38;5;130mhttps://ui.adsabs.harvard.edu/abs/1957RvMP...29..547B\x1b[0m\r\n\x1b[0;38;5;33mbibcode\x1b[0m: \x1b[0;38;5;130m1957RvMP...29..547B\x1b[0m\r\n\x1b[0;38;5;33mkey\x1b[0m: \x1b[0;38;5;142mBurbidgeEtal1957rvmpStellarElementSynthesis\x1b[0m\r\n\x1b[0m"
+    assert captured.out == expected_output
 
 
 @pytest.mark.parametrize('mock_prompt_session',
     [['author:"Burbidge, E"']], indirect=True)
-def test_cli_search_verbosity_one(capsys, mock_init_sample,
-        mock_prompt_session):
+def test_cli_search_verbosity_one(
+        capsys, mock_init_sample, mock_prompt_session):
     sys.argv = "bibm search -v 1".split()
     cli.main()
     captured = capsys.readouterr()
-    assert captured.out == """(Press 'tab' for autocomplete)\n\n
-Title: Synthesis of the Elements in Stars, 1957
-Authors: {Burbidge}, E. Margaret; et al.
-bibcode:   1957RvMP...29..547B
-ADS url:   https://ui.adsabs.harvard.edu/abs/1957RvMP...29..547B
-key: BurbidgeEtal1957rvmpStellarElementSynthesis\n"""
+    expected_output = "(Press 'tab' for autocomplete)\n\n\x1b[0m\x1b[?7h\x1b[0m\r\n\x1b[0;38;5;33mTitle\x1b[0m: \x1b[0;38;5;130mSynthesis of the Elements in Stars, 1957\x1b[0m\r\n\x1b[0;38;5;33mAuthors\x1b[0m: \x1b[0;38;5;130m{Burbidge}, E. Margaret; et al.\x1b[0m\r\n\x1b[0;38;5;33mADS URL\x1b[0m: \x1b[0;38;5;130mhttps://ui.adsabs.harvard.edu/abs/1957RvMP...29..547B\x1b[0m\r\n\x1b[0;38;5;33mbibcode\x1b[0m: \x1b[0;38;5;130m1957RvMP...29..547B\x1b[0m\r\n\x1b[0;38;5;33mkey\x1b[0m: \x1b[0;38;5;142mBurbidgeEtal1957rvmpStellarElementSynthesis\x1b[0m\r\n\x1b[0m"
+    assert captured.out == expected_output
 
 
 @pytest.mark.parametrize('mock_prompt_session',
     [['author:"Slipher, V"']], indirect=True)
-def test_cli_search_verbosity_meta(capsys, mock_init_sample,
-        mock_prompt_session):
+def test_cli_search_verbosity_meta(
+        capsys, mock_init_sample, mock_prompt_session):
     sys.argv = "bibm search -v 1".split()
     cli.main()
     captured = capsys.readouterr()
-    assert captured.out == """(Press 'tab' for autocomplete)\n\n
-Title: The radial velocity of the Andromeda Nebula, 1913
-Authors: {Slipher}, V. M.
-bibcode:   1913LowOB...2...56S
-ADS url:   https://ui.adsabs.harvard.edu/abs/1913LowOB...2...56S
-PDF file:  Slipher1913.pdf
-key: Slipher1913lobAndromedaRarialVelocity\n"""
+    expected_output = "(Press 'tab' for autocomplete)\n\n\x1b[0m\x1b[?7h\x1b[0m\r\n\x1b[0;38;5;33mTitle\x1b[0m: \x1b[0;38;5;130mThe radial velocity of the Andromeda Nebula, 1913\x1b[0m\r\n\x1b[0;38;5;33mAuthors\x1b[0m: \x1b[0;38;5;130m{Slipher}, V. M.\x1b[0m\r\n\x1b[0;38;5;33mADS URL\x1b[0m: \x1b[0;38;5;130mhttps://ui.adsabs.harvard.edu/abs/1913LowOB...2...56S\x1b[0m\r\n\x1b[0;38;5;33mbibcode\x1b[0m: \x1b[0;38;5;130m1913LowOB...2...56S\x1b[0m\r\n\x1b[0;38;5;33mPDF file\x1b[0m: \x1b[0;38;5;248;3mSlipher1913.pdf\x1b[0m\r\n\x1b[0;38;5;33mkey\x1b[0m: \x1b[0;38;5;142mSlipher1913lobAndromedaRarialVelocity\x1b[0m\r\n\x1b[0m"
+    assert captured.out == expected_output
 
 
 @pytest.mark.parametrize('mock_prompt_session',
@@ -432,13 +371,8 @@ def test_cli_search_verbosity_two(capsys, mock_init_sample,mock_prompt_session):
     sys.argv = "bibm search -v 2".split()
     cli.main()
     captured = capsys.readouterr()
-    assert captured.out == """(Press 'tab' for autocomplete)\n\n
-Title: Synthesis of the Elements in Stars, 1957
-Authors: {Burbidge}, E. Margaret; {Burbidge}, G. R.; {Fowler}, William A.; and
-         {Hoyle}, F.
-bibcode:   1957RvMP...29..547B
-ADS url:   https://ui.adsabs.harvard.edu/abs/1957RvMP...29..547B
-key: BurbidgeEtal1957rvmpStellarElementSynthesis\n"""
+    expected_output = "(Press 'tab' for autocomplete)\n\n\x1b[0m\x1b[?7h\x1b[0m\r\n\x1b[0;38;5;33mTitle\x1b[0m: \x1b[0;38;5;130mSynthesis of the Elements in Stars, 1957\x1b[0m\r\n\x1b[0;38;5;33mAuthors\x1b[0m: \x1b[0;38;5;130m{Burbidge}, E. Margaret; {Burbidge}, G. R.; {Fowler}, William A.; and\r\n    {Hoyle}, F.\x1b[0m\r\n\x1b[0;38;5;33mADS URL\x1b[0m: \x1b[0;38;5;130mhttps://ui.adsabs.harvard.edu/abs/1957RvMP...29..547B\x1b[0m\r\n\x1b[0;38;5;33mbibcode\x1b[0m: \x1b[0;38;5;130m1957RvMP...29..547B\x1b[0m\r\n\x1b[0;38;5;33mkey\x1b[0m: \x1b[0;38;5;142mBurbidgeEtal1957rvmpStellarElementSynthesis\x1b[0m\r\n\x1b[0m"
+    assert captured.out == expected_output
 
 
 @pytest.mark.parametrize('mock_prompt_session',
@@ -563,8 +497,10 @@ def test_cli_latex_invalid_extension(capsys, mock_init_sample, directive):
         "\nError: Input file does not have a .tex extension\n"
 
 
-@pytest.mark.parametrize('mock_prompt_session',
-    [['author:"^fortney, j" year:2000-2018 property:refereed']], indirect=True)
+@pytest.mark.parametrize(
+    'mock_prompt_session',
+    [['author:"^fortney, j" year:2000-2018 property:refereed']],
+    indirect=True)
 def test_cli_ads_search(capsys, reqs, mock_prompt_session, mock_init):
     cm.set('ads_display', '2')
     am.search.__defaults__ = 0, 2, 'pubdate+desc'
@@ -589,7 +525,8 @@ Showing entries 1--2 out of 26 matches.  To show the next set, execute:
 bibm ads-search -n\n"""
 
 
-@pytest.mark.parametrize('mock_prompt_session',
+@pytest.mark.parametrize(
+    'mock_prompt_session',
     [['author:"^fortney, j" year:2000-2018 property:refereed']],
     indirect=True)
 def test_cli_ads_search_next(capsys, reqs, mock_prompt_session, mock_init):
@@ -622,7 +559,8 @@ bibm ads-search -n\n"""
 @pytest.mark.parametrize('mock_prompt_session',
     [['', 'author:"^fortney, j" year:2000-2018 property:refereed']],
     indirect=True)
-def test_cli_ads_search_empty_next(capsys, reqs, mock_prompt_session, mock_init):
+def test_cli_ads_search_empty_next(
+        capsys, reqs, mock_prompt_session, mock_init):
     cm.set('ads_display', '2')
     am.search.__defaults__ = 0, 2, 'pubdate+desc'
     sys.argv = "bibm ads-search".split()
@@ -1344,11 +1282,10 @@ def test_cli_older_pickle(capsys, mock_init_sample, mock_prompt_session):
     sys.argv = "bibm search".split()
     cli.main()
     captured = capsys.readouterr()
-    assert captured.out == f"""Updating database file from version 0.0.0 to version {bibmanager.__version__}.
-(Press 'tab' for autocomplete)\n\n
-Title: Numpy: A guide to NumPy, 2006
-Authors: Oliphant, Travis
-key: Oliphant2006numpy\n"""
+    assert captured.out == (
+        "Updating database file from version 0.0.0 to version "
+        f"{bibmanager.__version__}.\n"
+        + expected_numpy)
 
 
 def test_cli_future_pickle(capsys, mock_init_sample):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -4,6 +4,7 @@
 import numpy as np
 import pytest
 
+from pygments.token import Token
 import bibmanager.utils as u
 
 
@@ -500,3 +501,45 @@ def test_req_input2(mock_input, capsys):
     assert captured.out == 'Enter number between 0 and 9: \n' \
                          + 'Not a valid input.  Try again: \n'
     assert r == "5"
+
+
+def test_tokenizer_default():
+    attribute = 'Title'
+    value = 'Synthesis of the Elements in Stars'
+    tokens = u.tokenizer(attribute, value)
+    assert len(tokens) == 4
+    # These are always the same:
+    assert tokens[0][0] == Token.Name.Attribute
+    assert tokens[1][0] == Token.Punctuation
+    assert tokens[3][0] == Token.Text
+    # Set by the arguments:
+    assert tokens[0][1] == attribute
+    assert tokens[2][0] == Token.Literal.String
+    assert tokens[2][1] == value
+
+
+def test_tokenizer_value_token():
+    attribute = 'Title'
+    value = 'Synthesis of the Elements in Stars'
+    value_token = Token.Name.Label
+    tokens = u.tokenizer(attribute, value, value_token=value_token)
+    assert len(tokens) == 4
+    # These are always the same:
+    assert tokens[0][0] == Token.Name.Attribute
+    assert tokens[1][0] == Token.Punctuation
+    assert tokens[3][0] == Token.Text
+    # Set by the arguments:
+    assert tokens[0][1] == attribute
+    assert tokens[2][0] == value_token
+    assert tokens[2][1] == value
+
+
+def test_tokenizer_value_none():
+    tokens = u.tokenizer('Title', None)
+    assert tokens == []
+
+
+def test_tokenizer_value_blank():
+    tokens = u.tokenizer('Title', '')
+    assert tokens == []
+


### PR DESCRIPTION
This new major version includes:
- Add the `tags` meta properties to the entries.  These are user-defined tags that the user can assign to the entries, which enable another mean to search and display
- Add the `bibm tag` command to set, remove, and display tags
- The `bibm browse` command now supports a tag shortcut to search, select, and display entries by tag
- Display formatted text (colorful screen outputs) for the `search` and `ads-search` commands
- Include python 3.8 and 3.9 testing into the travis.yml file (in addition to 3.6 and 3.7)
- Some improvements to the auto-complete/auto-suggest functionality for the search commands

Thanks @gmduvvuri and @AaronDavidSchneider for your suggestions!
This PR solves #75