### PR TITLE
Rebar

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -2626,3 +2626,7 @@ to prevent bug with auto-suggestions falling on top of quotes.
 
 Updated browser help text.
 
+*****
+
+Updated browser to stay at current loc when performing entry-searches
+by keywords.

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -2622,3 +2622,7 @@ Fixed minor issue with tests.
 Turned off complete_while_typing in browser entry-search bar
 to prevent bug with auto-suggestions falling on top of quotes.
 
+*****
+
+Updated browser help text.
+

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -2630,3 +2630,8 @@ Updated browser help text.
 
 Updated browser to stay at current loc when performing entry-searches
 by keywords.
+
+*****
+
+Bumped bibmanager to version 1.4.1
+

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -2616,3 +2616,9 @@ categorized by authors/years/tags/etc.
 
 Fixed minor issue with tests.
 
+
+*****  Mon Dec 20 15:16:36 CET 2021  *****
+
+Turned off complete_while_typing in browser entry-search bar
+to prevent bug with auto-suggestions falling on top of quotes.
+

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -2587,3 +2587,7 @@ Updated travis.yml file to include python versions 3.6 to 3.9
 Updated sample.bib file.
 Updated tests and other auxilliary scripts accordingly.
 
+*****
+
+Updated docs.
+

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -2612,3 +2612,7 @@ Revamped the 'tag search' of the browser to a general search toolbar
 which allows to search and display subsets of the entries
 categorized by authors/years/tags/etc.
 
+*****
+
+Fixed minor issue with tests.
+

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -2591,3 +2591,9 @@ Updated tests and other auxilliary scripts accordingly.
 
 Updated docs.
 
+*****
+
+Implemented u.parse_search() to parse the input texts that later go
+into bm.search().
+Documented and tested.
+

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -2581,3 +2581,9 @@ ValueError: 'style' is not a valid bibmanager config parameter.
 
 Updated travis.yml file to include python versions 3.6 to 3.9
 
+
+*****  Thu Dec 16 23:38:44 CET 2021  *****
+
+Updated sample.bib file.
+Updated tests and other auxilliary scripts accordingly.
+

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -2601,3 +2601,8 @@ Documented and tested.
 
 Replaced manual parsing cli_search() with u.parse_search().
 
+*****
+
+Tweaked how u.DynamicKeywordSuggester() gets the completer
+to also work in a full-screen application.
+

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -2597,3 +2597,7 @@ Implemented u.parse_search() to parse the input texts that later go
 into bm.search().
 Documented and tested.
 
+*****
+
+Replaced manual parsing cli_search() with u.parse_search().
+

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -2606,3 +2606,9 @@ Replaced manual parsing cli_search() with u.parse_search().
 Tweaked how u.DynamicKeywordSuggester() gets the completer
 to also work in a full-screen application.
 
+*****
+
+Revamped the 'tag search' of the browser to a general search toolbar
+which allows to search and display subsets of the entries
+categorized by authors/years/tags/etc.
+

--- a/bibmanager/VERSION.py
+++ b/bibmanager/VERSION.py
@@ -2,4 +2,4 @@
 # bibmanager is open-source software under the MIT license (see LICENSE).
 
 # bibmanager Version:
-__version__ = "1.4.0"
+__version__ = "1.4.1"

--- a/bibmanager/__main__.py
+++ b/bibmanager/__main__.py
@@ -4,7 +4,6 @@
 import argparse
 import itertools
 import os
-import re
 from datetime import date
 from packaging import version
 
@@ -159,50 +158,9 @@ def cli_search(args):
         validate_while_typing=True,
         bottom_toolbar=validator.bottom_toolbar)
 
-    # Parse inputs:
-    authors = re.findall(r'author:"([^"]+)', inputs)
-    title_kw = re.findall(r'title:"([^"]+)', inputs)
-    years = re.search(r'year:[\s]*([^\s]+)', inputs)
-    key = re.findall(r'key:[\s]*([^\s]+)', inputs)
-    bibcode = re.findall(r'bibcode:[\s]*([^\s]+)', inputs)
-    tags = re.findall(r'tags:[\s]*([^\s]+)', inputs)
-
-    if years is not None:
-        years = years.group(1)
-    if len(key) == 0:
-        key = None
-    if len(bibcode) == 0:
-        bibcode = None
-    if len(tags) == 0:
-        tags = []
-
-    # Cast year string to integer or list of integers:
-    if years is None:
-        pass
-    elif len(years) == 4 and years.isnumeric():
-        years = int(years)
-    elif len(years) == 5 and years.startswith('-') and years[1:].isnumeric():
-        years = [0, int(years[1:])]
-    elif len(years) == 5 and years.endswith('-') and years[0:4].isnumeric():
-        years = [int(years[0:4]), 9999]
-    elif len(years) == 9 and years[0:4].isnumeric() and years[5:].isnumeric():
-        years = [int(years[0:4]), int(years[5:9])]
-    else:
-        print(f"\nInvalid format for input year: {years}")
+    matches = u.parse_search(inputs)
+    if len(matches) == 0:
         return
-
-    empty_search = (
-        len(authors) == 0
-        and len(title_kw) == 0
-        and years is None
-        and key is None
-        and bibcode is None
-        and len(tags) == 0
-    )
-    if empty_search:
-        return
-
-    matches = bm.search(authors, years, title_kw, key, bibcode, tags)
     # Catch case when user sets '-v' without arguments:
     if args.verb is None:
         print(
@@ -761,7 +719,7 @@ Examples
 
   # Search by author, year, and title words/phrases (using AND logic):
   bibm search
-  author:"oliphant, t" year:2006 title:"numpy"
+  author:"oliphant, t" year:2020 title:"numpy"
 
   # Search multiple words/phrases in title (using AND logic):
   bibm search
@@ -769,13 +727,13 @@ Examples
 
   # Search on specific year:
   bibm search
-  author:"cubillos, p" year:2016
+  author:"cubillos, p" year:2019
   # Search anything between the specified years:
   bibm search
-  author:"cubillos, p" year:2014-2016
+  author:"cubillos, p" year:2018-2020
   # Search anything up to the specified year:
   bibm search
-  author:"cubillos, p" year:-2016
+  author:"cubillos, p" year:-2020
   # Search anything since the specified year:
   bibm search
   author:"cubillos, p" year:2016-

--- a/bibmanager/bib_manager/bib_manager.py
+++ b/bibmanager/bib_manager/bib_manager.py
@@ -1108,7 +1108,7 @@ def edit():
 def search(authors=None, year=None, title=None, key=None, bibcode=None,
         tags=None):
     """
-    Search in bibmanager database by authors, year, or title keywords.
+    Search in bibmanager database by different fields/properties.
 
     Parameters
     ----------

--- a/bibmanager/bib_manager/browser.py
+++ b/bibmanager/bib_manager/browser.py
@@ -501,15 +501,17 @@ def browse():
 
 
     @bindings.add("f", filter=text_focus)
-    def _start_search(event):
+    def _start_literal_search(event):
         search.start_search(direction=search.SearchDirection.FORWARD)
+
 
     # TBD: Remove 't' binding no before 17/12/2022
     @bindings.add("t", filter=text_focus)
     @bindings.add("k", filter=text_focus)
-    def _start_tag_search(event):
+    def _start_entry_search(event):
+        text_field.current_key = get_current_key(
+            event.current_buffer.document, keys)
         event.app.layout.focus(entry_search_field)
-        search.start_search(direction=search.SearchDirection.FORWARD)
 
 
     @bindings.add("b", filter=text_focus)
@@ -567,7 +569,7 @@ def browse():
 
 
     @bindings.add("enter", filter=entry_search_focus)
-    def _select_tags(event):
+    def _select_entries(event):
         "Parse the input tag text and send focus back to main text."
         # Reset tag text to '':
         doc = event.current_buffer.document
@@ -594,20 +596,25 @@ def browse():
         # Update main text with selected tag:
         buffer = event.current_buffer
         text_field.text = text_field.compact_text
-        buffer.cursor_position = 0
+        if text_field.current_key in search_buffer.completer.words:
+            buffer_position = text_field.text.index(text_field.current_key)
+        else:
+            buffer_position = 0
+        buffer.cursor_position = buffer_position
         text_field.is_expanded = False
 
     # TBD: Remove 'T' binding no before 17/12/2022
     @bindings.add("T", filter=text_focus)
     @bindings.add("K", filter=text_focus)
     def _deselect_tags(event):
+        buffer = event.current_buffer
+        key = get_current_key(buffer.document, keys)
         text_field.compact_text = all_compact_text[:]
         text_field.expanded_text = all_expanded_text[:]
         search_buffer.completer.words = keys
         # Update main text:
-        buffer = event.current_buffer
         text_field.text = text_field.compact_text
-        buffer.cursor_position = 0
+        buffer.cursor_position = buffer.text.index(key)
         text_field.is_expanded = False
 
 

--- a/bibmanager/bib_manager/browser.py
+++ b/bibmanager/bib_manager/browser.py
@@ -71,8 +71,9 @@ e       Expand/collapse content of current entry
 E       Expand/collapse all entries
 o       Open PDF of entry (ask to fetch if needed)
 b       Open entry in ADS through the web browser
-k       Search by keyword fields (authors/years/tags etc)
-K       Clear search-subset selection
+k       Search entries by keywords (authors/years/tags/etc),
+          displaying only matching entries
+K       Clear keyword-search selection
 q       Quit
 
 Navigation

--- a/bibmanager/bib_manager/browser.py
+++ b/bibmanager/bib_manager/browser.py
@@ -365,11 +365,9 @@ def browse():
     auto_suggest_bindings = load_auto_suggest_bindings()
 
     # Searcher:
-    tags = sorted(set(itertools.chain(
-        *[bib.tags for bib in bibs if bib.tags is not None])))
-    tag_buffer = Buffer(
+    entry_search_buffer = Buffer(
         completer=completer,
-        complete_while_typing=True,
+        complete_while_typing=False,
         auto_suggest=suggester,
     )
 
@@ -377,7 +375,7 @@ def browse():
         return FormattedText([('bold', 'Entry search: '),])
     entry_search_field = Window(
         BufferControl(
-            buffer=tag_buffer,
+            buffer=entry_search_buffer,
             input_processors=[AppendAutoSuggestion()],
         ),
         get_line_prefix=get_line_prefix,

--- a/bibmanager/bib_manager/browser.py
+++ b/bibmanager/bib_manager/browser.py
@@ -14,6 +14,7 @@ import re
 import textwrap
 import webbrowser
 
+
 from prompt_toolkit import print_formatted_text, search
 from prompt_toolkit.application import Application
 from prompt_toolkit.application.current import get_app
@@ -23,8 +24,13 @@ from prompt_toolkit.filters import Condition
 from prompt_toolkit.formatted_text import PygmentsTokens, FormattedText
 from prompt_toolkit.formatted_text.utils import fragment_list_to_text
 from prompt_toolkit.key_binding import KeyBindings
+from prompt_toolkit.key_binding.key_bindings import merge_key_bindings
+from prompt_toolkit.key_binding.bindings.auto_suggest import \
+    load_auto_suggest_bindings
 from prompt_toolkit.key_binding.bindings.scroll import (
-    scroll_half_page_down, scroll_half_page_up,)
+    scroll_half_page_down,
+    scroll_half_page_up,
+)
 from prompt_toolkit.layout.containers import (
     Float, FloatContainer,
     HSplit, VSplit,
@@ -34,7 +40,11 @@ from prompt_toolkit.layout.controls import FormattedTextControl, BufferControl
 from prompt_toolkit.layout.dimension import D
 from prompt_toolkit.layout.layout import Layout
 from prompt_toolkit.layout.menus import CompletionsMenu
-from prompt_toolkit.layout.processors import Transformation, Processor
+from prompt_toolkit.layout.processors import (
+    Transformation,
+    Processor,
+    AppendAutoSuggestion,
+)
 from prompt_toolkit.layout.utils import explode_text_fragments
 from prompt_toolkit.lexers import PygmentsLexer
 from prompt_toolkit.selection import PasteMode
@@ -56,13 +66,13 @@ help_message = f"""\
 h       Show this message
 enter   Select/unselect entry for saving
 s       Save selected entries to file or screen output
-f,/,?   Start forward (f or /) or reverse (?) search
+f,/,?   Find literal string in the main text
 e       Expand/collapse content of current entry
 E       Expand/collapse all entries
 o       Open PDF of entry (ask to fetch if needed)
 b       Open entry in ADS through the web browser
-t       Start search by tag
-T       Clear tag selection
+k       Search by keyword fields (authors/years/tags etc)
+K       Clear search-subset selection
 q       Quit
 
 Navigation
@@ -309,31 +319,75 @@ def browse():
         completer=WordCompleter(keys),
         complete_while_typing=False,
         multiline=False)
-    search_field = SearchToolbar(
+    literal_search_field = SearchToolbar(
         search_buffer=search_buffer,
-        forward_search_prompt = "Search: ",
-        backward_search_prompt = "Search backward: ",
+        forward_search_prompt = "Text search: ",
+        backward_search_prompt = "Text search backward: ",
         ignore_case=False)
 
-    # Tag searcher:
+    # Entry search bar:
+    authors_list = [bib.authors for bib in bibs]
+    firsts = sorted(set([
+        u.get_authors([authors[0]], format='ushort')
+        for authors in authors_list
+        if authors is not None]))
+    firsts = [
+        '^{'+first+'}' if ' ' in first else '^'+first
+        for first in firsts]
+
+    lasts = sorted(set([
+        u.get_authors([author], format='ushort')
+        for authors in authors_list if authors is not None
+        for author in authors]))
+    lasts = [
+        '{'+last+'}' if ' ' in last else last
+        for last in lasts]
+
+    bibkeys = [bib.key for bib in bibs]
+    bibcodes = [bib.bibcode for bib in bibs if bib.bibcode is not None]
+    bibyears = sorted(set([
+        str(bib.year) for bib in bibs if bib.year is not None]))
+    titles = [bib.title for bib in bibs]
+    tags = sorted(set(itertools.chain(
+        *[bib.tags for bib in bibs if bib.tags is not None])))
+
+    key_words = {
+        'author:"^"': firsts,
+        'author:""': lasts,
+        'year:': bibyears,
+        'title:""': titles,
+        'key:': bibkeys,
+        'bibcode:': bibcodes,
+        'tags:': tags,
+    }
+    completer = u.DynamicKeywordCompleter(key_words)
+    suggester = u.DynamicKeywordSuggester()
+    auto_suggest_bindings = load_auto_suggest_bindings()
+
+    # Searcher:
     tags = sorted(set(itertools.chain(
         *[bib.tags for bib in bibs if bib.tags is not None])))
     tag_buffer = Buffer(
-        completer=WordCompleter(tags),
+        completer=completer,
         complete_while_typing=True,
+        auto_suggest=suggester,
     )
+
     def get_line_prefix(lineno, wrap_count):
-        return FormattedText([('bold', 'Tag search: '),])
-    tag_field = Window(
-        BufferControl(buffer=tag_buffer),
+        return FormattedText([('bold', 'Entry search: '),])
+    entry_search_field = Window(
+        BufferControl(
+            buffer=tag_buffer,
+            input_processors=[AppendAutoSuggestion()],
+        ),
         get_line_prefix=get_line_prefix,
         height=1)
     # Wrap in conditional container to display it only when focused:
-    tag_focus = Condition(
-        lambda: get_app().layout.current_window == tag_field)
-    tag_container = ConditionalContainer(
-        content=tag_field,
-        filter=tag_focus,
+    entry_search_focus = Condition(
+        lambda: get_app().layout.current_window == entry_search_field)
+    entry_search_container = ConditionalContainer(
+        content=entry_search_field,
+        filter=entry_search_focus,
     )
 
     text_field = TextArea(
@@ -342,7 +396,7 @@ def browse():
         scrollbar=True,
         line_numbers=False,
         read_only=True,
-        search_field=search_field,
+        search_field=literal_search_field,
         input_processors=[HighlightEntryProcessor()],
     )
     text_field.buffer.name = 'text_area_buffer'
@@ -377,14 +431,14 @@ def browse():
             height=D.exact(1),
             style="class:status",
         ),
-        filter=~tag_focus,
+        filter=~entry_search_focus,
     )
 
     body = HSplit([
         menu_bar,
         text_field,
-        search_field,
-        tag_container,
+        literal_search_field,
+        entry_search_container,
         info_bar,
     ])
 
@@ -451,10 +505,11 @@ def browse():
     def _start_search(event):
         search.start_search(direction=search.SearchDirection.FORWARD)
 
-
+    # TBD: Remove 't' binding no before 17/12/2022
     @bindings.add("t", filter=text_focus)
+    @bindings.add("k", filter=text_focus)
     def _start_tag_search(event):
-        event.app.layout.focus(tag_field)
+        event.app.layout.focus(entry_search_field)
         search.start_search(direction=search.SearchDirection.FORWARD)
 
 
@@ -512,7 +567,7 @@ def browse():
         text_field.bm_processor.toggle_selected_entry(key)
 
 
-    @bindings.add("enter", filter=tag_focus)
+    @bindings.add("enter", filter=entry_search_focus)
     def _select_tags(event):
         "Parse the input tag text and send focus back to main text."
         # Reset tag text to '':
@@ -522,9 +577,8 @@ def browse():
         event.current_buffer.delete(
             doc.get_end_of_line_position() - doc.get_start_of_line_position())
 
-        # Catch text and parse tags:
-        tags_list = doc.current_line.split()
-        matches = bm.search(tags=tags_list)
+        # Catch text and parse search text:
+        matches = u.parse_search(doc.current_line)
         if len(matches) == 0:
             text_field.compact_text = all_compact_text[:]
             text_field.expanded_text = all_expanded_text[:]
@@ -544,7 +598,9 @@ def browse():
         buffer.cursor_position = 0
         text_field.is_expanded = False
 
+    # TBD: Remove 'T' binding no before 17/12/2022
     @bindings.add("T", filter=text_focus)
+    @bindings.add("K", filter=text_focus)
     def _deselect_tags(event):
         text_field.compact_text = all_compact_text[:]
         text_field.expanded_text = all_expanded_text[:]
@@ -651,10 +707,13 @@ def browse():
                     pm.open(key=key)
         ensure_future(coroutine())
 
-
+    key_bindings = merge_key_bindings([
+        auto_suggest_bindings,
+        bindings,
+    ])
     application = Application(
         layout=Layout(root_container, focused_element=text_field),
-        key_bindings=bindings,
+        key_bindings=key_bindings,
         enable_page_navigation_bindings=True,
         style=style,
         full_screen=True,

--- a/bibmanager/examples/sample.bib
+++ b/bibmanager/examples/sample.bib
@@ -72,59 +72,17 @@ keywords = {methods: data analysis, methods: miscellaneous, virtual observatory 
       adsnote = {Provided by the SAO/NASA Astrophysics Data System}
 }
 
-@ARTICLE{CubillosEtal2013apjWASP8b,
-       author = {{Cubillos}, Patricio and {Harrington}, Joseph and {Madhusudhan}, Nikku
-        and {Stevenson}, Kevin B. and {Hardy}, Ryan A. and {Blecic},
-        Jasmina and {Anderson}, David R. and {Hardin}, Matthew and
-        {Campo}, Christopher J.},
-        title = "{WASP-8b: Characterization of a Cool and Eccentric Exoplanet with Spitzer}",
-      journal = {\apj},
-     keywords = {planetary systems, stars: individual: WASP-8, techniques: photometric, Astrophysics - Earth and Planetary Astrophysics},
-         year = 2013,
-        month = May,
-       volume = {768},
-          eid = {42},
-        pages = {42},
-          doi = {10.1088/0004-637X/768/1/42},
-archivePrefix = {arXiv},
-       eprint = {1303.5468},
- primaryClass = {astro-ph.EP},
-       adsurl = {https://ui.adsabs.harvard.edu/abs/2013ApJ...768...42C},
-      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
-}
-
-@ARTICLE{Cubillos2016phdThesis,
+freeze
+@MISC{Cubillos2019zndoBibmanager,
        author = {{Cubillos}, Patricio E.},
-        title = "{Characterizing Exoplanet Atmospheres: From Light-curve Observations to Radiative-transfer Modeling}",
-      journal = {arXiv e-prints},
-     keywords = {Astrophysics - Earth and Planetary Astrophysics},
-         year = 2016,
-        month = Apr,
-          eid = {arXiv:1604.01320},
-        pages = {arXiv:1604.01320},
-archivePrefix = {arXiv},
-       eprint = {1604.01320},
- primaryClass = {astro-ph.EP},
-       adsurl = {https://ui.adsabs.harvard.edu/abs/2016arXiv160401320C},
-      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
-}
-
-@ARTICLE{CubillosEtal2017apjRednoise,
-       author = {{Cubillos}, Patricio and {Harrington}, Joseph and {Loredo}, Thomas J.
-        and {Lust}, Nate B. and {Blecic}, Jasmina and {Stemm}, Madison},
-        title = "{On Correlated-noise Analyses Applied to Exoplanet Light Curves}",
-      journal = {\aj},
-     keywords = {methods: statistical, planets and satellites: fundamental parameters, techniques: photometric, Astrophysics - Earth and Planetary Astrophysics},
-         year = 2017,
-        month = Jan,
-       volume = {153},
-          eid = {3},
-        pages = {3},
-          doi = {10.3847/1538-3881/153/1/3},
-archivePrefix = {arXiv},
-       eprint = {1610.01336},
- primaryClass = {astro-ph.EP},
-       adsurl = {https://ui.adsabs.harvard.edu/abs/2017AJ....153....3C},
+        title = "{bibmanager: A BibTeX manager for LaTeX projects, Zenodo, doi:\href{https://zenodo.org/record/2547042}{10.5281/zenodo.2547042}}",
+         year = 2019,
+        month = apr,
+          eid = {10.5281/zenodo.2547042},
+          doi = {10.5281/zenodo.2547042},
+      version = {v1.1.0},
+    publisher = {Zenodo},
+       adsurl = {https://ui.adsabs.harvard.edu/abs/2019zndo...2547042C},
       adsnote = {Provided by the SAO/NASA Astrophysics Data System}
 }
 
@@ -141,6 +99,24 @@ archivePrefix = {arXiv},
   adsnote = {Provided by the SAO/NASA Astrophysics Data System}
 }
 
+@ARTICLE{HarrisEtal2020natNumpy,
+       author = {{Harris}, Charles R. and {Millman}, K. Jarrod and {van der Walt}, St{\'e}fan J. and {Gommers}, Ralf and {Virtanen}, Pauli and {Cournapeau}, David and {Wieser}, Eric and {Taylor}, Julian and {Berg}, Sebastian and {Smith}, Nathaniel J. and {Kern}, Robert and {Picus}, Matti and {Hoyer}, Stephan and {van Kerkwijk}, Marten H. and {Brett}, Matthew and {Haldane}, Allan and {del R{\'\i}o}, Jaime Fern{\'a}ndez and {Wiebe}, Mark and {Peterson}, Pearu and {G{\'e}rard-Marchant}, Pierre and {Sheppard}, Kevin and {Reddy}, Tyler and {Weckesser}, Warren and {Abbasi}, Hameer and {Gohlke}, Christoph and {Oliphant}, Travis E.},
+        title = "{Array programming with NumPy}",
+      journal = {\nat},
+     keywords = {Computer Science - Mathematical Software, Statistics - Computation},
+         year = 2020,
+        month = sep,
+       volume = {585},
+       number = {7825},
+        pages = {357-362},
+          doi = {10.1038/s41586-020-2649-2},
+archivePrefix = {arXiv},
+       eprint = {2006.10256},
+ primaryClass = {cs.MS},
+       adsurl = {https://ui.adsabs.harvard.edu/abs/2020Natur.585..357H},
+      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
+
 @Article{Hunter2007ieeeMatplotlib,
   Author    = {{Hunter}, J. D.},
   Title     = {Matplotlib: A 2D graphics environment},
@@ -155,13 +131,6 @@ archivePrefix = {arXiv},
   publisher = {IEEE COMPUTER SOC},
   doi       = {10.1109/MCSE.2007.55},
   year      = 2007
-}
-
-@Misc{JonesEtal2001scipy,
-  author = {Eric Jones and Travis Oliphant and Pearu Peterson and others},
-  title  = {{SciPy}: Open source scientific tools for {Python}},
-  year   = {2001},
-  url    = "http://www.scipy.org/",
 }
 
 @article{MeurerEtal2017pjcsSYMPY,
@@ -238,24 +207,21 @@ pdf: Slipher1913.pdf
       adsnote = {Provided by the SAO/NASA Astrophysics Data System}
 }
 
-@Misc{Oliphant2006numpy,
-   author = {Travis Oliphant},
-    title = {{Numpy}: A guide to {NumPy}},
-     year = {2006},
-      url = "http://www.numpy.org/",
-}
-
-@article{vanderWaltEtal2011numpy,
-   author = {St{\'{e}}fan van der Walt and S. Chris Colbert and Ga{\"{e}}l Varoquaux},
-  journal = {Computing in Science \& Engineering},
-   volume = {13},
-   number = {},
-     issn = {1521-9615},
-     year = {2011},
-    pages = {22-30},
-      doi = {doi.ieeecomputersociety.org/10.1109/MCSE.2011.37},
-publisher = {IEEE Computer Society},
-  address = {Los Alamitos, CA, USA},
+@ARTICLE{VirtanenEtal2020natmeScipy,
+       author = {{Virtanen}, Pauli and {Gommers}, Ralf and {Oliphant}, Travis E. and {Haberland}, Matt and {Reddy}, Tyler and {Cournapeau}, David and {Burovski}, Evgeni and {Peterson}, Pearu and {Weckesser}, Warren and {Bright}, Jonathan and {van der Walt}, St{\'e}fan J. and {Brett}, Matthew and {Wilson}, Joshua and {Millman}, K. Jarrod and {Mayorov}, Nikolay and {Nelson}, Andrew R.~J. and {Jones}, Eric and {Kern}, Robert and {Larson}, Eric and {Carey}, C.~J. and {Polat}, {\.I}lhan and {Feng}, Yu and {Moore}, Eric W. and {VanderPlas}, Jake and {Laxalde}, Denis and {Perktold}, Josef and {Cimrman}, Robert and {Henriksen}, Ian and {Quintero}, E.~A. and {Harris}, Charles R. and {Archibald}, Anne M. and {Ribeiro}, Ant{\^o}nio H. and {Pedregosa}, Fabian and {van Mulbregt}, Paul and {SciPy 1. 0 Contributors}},
+        title = "{SciPy 1.0: fundamental algorithms for scientific computing in Python}",
+      journal = {Nature Methods},
+     keywords = {Computer Science - Mathematical Software, Computer Science - Data Structures and Algorithms, Computer Science - Software Engineering, Physics - Computational Physics},
+         year = 2020,
+        month = feb,
+       volume = {17},
+        pages = {261-272},
+          doi = {10.1038/s41592-019-0686-2},
+archivePrefix = {arXiv},
+       eprint = {1907.10121},
+ primaryClass = {cs.MS},
+       adsurl = {https://ui.adsabs.harvard.edu/abs/2020NatMe..17..261V},
+      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
 }
 
 @Misc{JonesNoYearScipy,
@@ -265,7 +231,6 @@ publisher = {IEEE Computer Society},
 
 @MISC{1978windEnergyReport,
         title = "{Wind energy systems: Program summary}",
- howpublished = {Unknown},
          year = 1978,
         month = dec,
        adsurl = {https://ui.adsabs.harvard.edu/abs/1978wes..rept......},

--- a/bibmanager/examples/sample.tex
+++ b/bibmanager/examples/sample.tex
@@ -66,17 +66,14 @@ modifications that are available at
 {https://github.com/pcubillos/ApJtemplate}.
 
 \software{
-\textsc{Numpy}  \citep{vanderWaltEtal2011numpy},
-\textsc{SciPy}  \citep{JonesEtal2001scipy},
+\textsc{Numpy}  \citep{HarrisEtal2020natNumpy},
+\textsc{SciPy}  \citep{VirtanenEtal2020natmeScipy},
 \textsc{Matplotlib} \citep{Hunter2007ieeeMatplotlib},
 \textsc{IPython} \citep{PerezGranger2007cseIPython}
 \textsc{sympy}  \citep{MeurerEtal2017pjcsSYMPY},
 \textsc{Astropy} \citep{Astropycollab2013aaAstropy},
 AASTeX6.2 \citep{AASteamHendrickson2018aastex62},
-ApJtemplate (\href{https://github.com/pcubillos/ApJtemplate}
-                  {https://github.com/pcubillos/ApJtemplate}),
-\textsc{bibmanager} (\href{http://pcubillos.github.io/bibmanager}
-                          {http://pcubillos.github.io/bibmanager}).
+\textsc{bibmanager} \citep{Cubillos2019zndoBibmanager}.
 }
 \bibliography{texsample}
 

--- a/bibmanager/utils/utils.py
+++ b/bibmanager/utils/utils.py
@@ -1250,7 +1250,10 @@ class DynamicKeywordCompleter(WordCompleter):
 class DynamicKeywordSuggester(AutoSuggest):
     """Give dynamic suggestions as in DynamicKeywordCompleter."""
     def get_suggestion(self, buffer, document):
-        completer = buffer.completer.get_completer()
+        if hasattr(buffer.completer, 'get_completer'):
+            completer = buffer.completer.get_completer()
+        else:
+            completer = buffer.completer
         # Consider only the last line for the suggestion:
         text = document.text[0:document.cursor_position_col]
 

--- a/docs/bibtex.rst
+++ b/docs/bibtex.rst
@@ -386,13 +386,15 @@ Name examples:
   (Press 'tab' for autocomplete)
   author:"oliphant"
 
-  Title: SciPy: Open source scientific tools for Python, 2001
-  Authors: Jones, Eric; et al.
-  key: JonesEtal2001scipy
+  Title: Array programming with NumPy, 2020
+  Authors: {Harris}, Charles R.; et al.
+  key: HarrisEtal2020natNumpy
 
-  Title: Numpy: A guide to NumPy, 2006
-  Authors: Oliphant, Travis
-  key: Oliphant2006numpy
+  Title: SciPy 1.0: fundamental algorithms for scientific computing in Python,
+      2020
+  Authors: {Virtanen}, Pauli; et al.
+  key: VirtanenEtal2020natmeScipy
+
 
 .. code-block:: shell
 
@@ -401,34 +403,43 @@ Name examples:
   (Press 'tab' for autocomplete)
   author:"oliphant, t"
 
-  Title: SciPy: Open source scientific tools for Python, 2001
-  Authors: Jones, Eric; et al.
-  key: JonesEtal2001scipy
+  Title: Array programming with NumPy, 2020
+  Authors: {Harris}, Charles R.; et al.
+  key: HarrisEtal2020natNumpy
 
-  Title: Numpy: A guide to NumPy, 2006
-  Authors: Oliphant, Travis
-  key: Oliphant2006numpy
+  Title: SciPy 1.0: fundamental algorithms for scientific computing in Python,
+      2020
+  Authors: {Virtanen}, Pauli; et al.
+  key: VirtanenEtal2020natmeScipy
+
 
 .. code-block:: shell
 
   # Search by first-author only:
   bibm search
-  author:"^oliphant, t"
+  author:"^Harris"
 
-  Title: Numpy: A guide to NumPy, 2006
-  Authors: Oliphant, Travis
-  key: Oliphant2006numpy
+  Title: Array programming with NumPy, 2020
+  Authors: {Harris}, Charles R.; et al.
+  key: HarrisEtal2020natNumpy
+
 
 .. code-block:: shell
 
   # Search multiple authors (using AND logic):
   bibm search
   (Press 'tab' for autocomplete)
-  author:"oliphant, t" author:"jones, e"
+  author:"harris" author:"virtanen"
 
-  Title: SciPy: Open source scientific tools for Python, 2001
-  Authors: Jones, Eric; et al.
-  key: JonesEtal2001scipy
+  Title: Array programming with NumPy, 2020
+  Authors: {Harris}, Charles R.; et al.
+  key: HarrisEtal2020natNumpy
+
+  Title: SciPy 1.0: fundamental algorithms for scientific computing in Python,
+      2020
+  Authors: {Virtanen}, Pauli; et al.
+  key: VirtanenEtal2020natmeScipy
+
 
 Combine search fields:
 
@@ -437,11 +448,12 @@ Combine search fields:
   # Search by author, year, and title words/phrases (using AND logic):
   bibm search
   (Press 'tab' for autocomplete)
-  author:"oliphant, t" year:2006 title:"numpy"
+  author:"oliphant, t"  title:"numpy"
 
-  Title: Numpy: A guide to NumPy, 2006
-  Authors: Oliphant, Travis
-  key: Oliphant2006numpy
+  Title: Array programming with NumPy, 2020
+  Authors: {Harris}, Charles R.; et al.
+  key: HarrisEtal2020natNumpy
+
 
 .. code-block:: shell
 
@@ -464,63 +476,60 @@ Year examples:
   # Search on specific year:
   bibm search
   (Press 'tab' for autocomplete)
-  author:"cubillos, p" year:2016
+  year: 1913
 
-  Title: Characterizing Exoplanet Atmospheres: From Light-curve Observations to
-         Radiative-transfer Modeling, 2016
-  Authors: {Cubillos}, Patricio E.
-  key: Cubillos2016phdThesis
+  Title: The radial velocity of the Andromeda Nebula, 1913
+  Authors: {Slipher}, V. M.
+  key: Slipher1913lobAndromedaRarialVelocity
+
 
 .. code-block:: shell
 
   # Search anything between the specified years (inclusive):
   bibm search
   (Press 'tab' for autocomplete)
-  author:"cubillos, p" year:2013-2016
+  year:2013-2016
 
-  Title: WASP-8b: Characterization of a Cool and Eccentric Exoplanet with
-       Spitzer, 2013
-  Authors: {Cubillos}, Patricio; et al.
-  key: CubillosEtal2013apjWASP8b
+  Title: Novae in the Spiral Nebulae and the Island Universe Theory, 1917
+  Authors: {Curtis}, H. D.
+  key: Curtis1917paspIslandUniverseTheory
 
+  Title: The radial velocity of the Andromeda Nebula, 1913
+  Authors: {Slipher}, V. M.
+  key: Slipher1913lobAndromedaRarialVelocity
 
-  Title: Characterizing Exoplanet Atmospheres: From Light-curve Observations to
-         Radiative-transfer Modeling, 2016
-  Authors: {Cubillos}, Patricio E.
-  key: Cubillos2016phdThesis
 
 .. code-block:: shell
 
   # Search anything up to the specified year (note this syntax is not available on ADS):
   bibm search
   (Press 'tab' for autocomplete)
-  author:"cubillos, p" year:-2016
+  year: -1917
 
-  Title: WASP-8b: Characterization of a Cool and Eccentric Exoplanet with
-         Spitzer, 2013
-  Authors: {Cubillos}, Patricio; et al.
-  key: CubillosEtal2013apjWASP8b
+  Title: Novae in the Spiral Nebulae and the Island Universe Theory, 1917
+  Authors: {Curtis}, H. D.
+  key: Curtis1917paspIslandUniverseTheory
 
-  Title: Characterizing Exoplanet Atmospheres: From Light-curve Observations to
-         Radiative-transfer Modeling, 2016
-  Authors: {Cubillos}, Patricio E.
-  key: Cubillos2016phdThesis
+  Title: The radial velocity of the Andromeda Nebula, 1913
+  Authors: {Slipher}, V. M.
+  key: Slipher1913lobAndromedaRarialVelocity
 
 .. code-block:: shell
 
   # Search anything since the specified year:
   bibm search
   (Press 'tab' for autocomplete)
-  author:"cubillos, p" year:2016-
+  author:"oliphant, t" year: 2020-
 
-  Title: Characterizing Exoplanet Atmospheres: From Light-curve Observations to
-         Radiative-transfer Modeling, 2016
-  Authors: {Cubillos}, Patricio E.
-  key: Cubillos2016phdThesis
+  Title: Array programming with NumPy, 2020
+  Authors: {Harris}, Charles R.; et al.
+  key: HarrisEtal2020natNumpy
 
-  Title: On Correlated-noise Analyses Applied to Exoplanet Light Curves, 2017
-  Authors: {Cubillos}, Patricio; et al.
-  key: CubillosEtal2017apjRednoise
+  Title: SciPy 1.0: fundamental algorithms for scientific computing in Python,
+      2020
+  Authors: {Virtanen}, Pauli; et al.
+  key: VirtanenEtal2020natmeScipy
+
 
 ADS bibcode examples (same applies to searches by key):
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,7 @@
 # Copyright (c) 2018-2021 Patricio Cubillos.
 # bibmanager is open-source software under the MIT license (see LICENSE).
 
+from contextlib import contextmanager
 import os
 import shutil
 import urllib
@@ -13,8 +14,22 @@ import bibmanager.bib_manager as bm
 import bibmanager.utils as u
 
 
+@contextmanager
+def cd(newdir):
+    """
+    Context manager for changing the current working directory.
+    Taken from here: https://stackoverflow.com/questions/431684/
+    """
+    olddir = os.getcwd()
+    os.chdir(os.path.expanduser(newdir))
+    try:
+        yield
+    finally:
+        os.chdir(olddir)
+
+
 # Number of entries in bibmanager/examples/sample.bib:
-nentries = 19
+nentries = 16
 
 
 @pytest.fixture
@@ -187,16 +202,24 @@ archivePrefix = "arXiv",
   year      = 2007
 }"""
 
-    oliphant_dup = """@Misc{Oliphant2006numpy,
-   author = {Travis Oliphant},
-    title = {{Numpy}: A guide to {NumPy}, Part B},
-     year = {2006},
+    slipher_dup = """@ARTICLE{Slipher1913lobAndromedaRarialVelocity,
+       author = {{Slipher}, V.~M.},
+        title = "{The radial velocity of the Andromeda Nebula, The real deal}",
+      journal = {Lowell Observatory Bulletin},
+         year = 1913,
+        month = Jan,
+       volume = {1},
+        pages = {56-57},
 }"""
 
-    no_oliphant = """@Misc{NoOliphant2020,
-   author = {Oliphant, No},
-    title = {{Numpy}: A guide to {NumPy}},
-     year = {2020},
+    slipher_guy = """@ARTICLE{Slipher1913lobAndromedaRarialVelocity,
+       author = {{Slipher}, G.},
+        title = "{The radial velocity of the Andromeda Nebula, The real deal}",
+      journal = {Lowell Observatory Bulletin},
+         year = 1913,
+        month = Jan,
+       volume = {1},
+        pages = {56-57},
 }"""
 
     sing = '''@ARTICLE{SingEtal2016natHotJupiterTransmission,
@@ -238,7 +261,7 @@ archivePrefix = "arXiv",
        author = {{Parmentier}, Vivien and {Crossfield}, Ian J.~M.},
         title = "{Exoplanet Phase Curves: Observations and Theory}",
          year = 2018,
-          doi = {10.1007/978-3-319-55333-7\_116},
+          doi = {10.1007/978-3-319-55333-7\\_116},
          isbn = "978-3-319-55333-7",
 }"""
 
@@ -247,7 +270,7 @@ archivePrefix = "arXiv",
        author = {{Cowan}, Nicolas B. and {Fujii}, Yuka},
         title = "{Mapping Exoplanets}",
          year = 2018,
-          doi = {10.1007/978-3-319-55333-7\_147},
+          doi = {10.1007/978-3-319-55333-7\\_147},
          isbn = "978-3-319-55333-7",
 }"""
 
@@ -277,8 +300,8 @@ archivePrefix = "arXiv",
         'beaulieu_arxiv': beaulieu_arxiv,
         'beaulieu_arxiv_dup': beaulieu_arxiv_dup,
         'hunter': hunter,
-        'oliphant_dup': oliphant_dup,
-        'no_oliphant': no_oliphant,
+        'slipher_dup': slipher_dup,
+        'slipher_guy': slipher_guy,
         'sing': sing,
         'stodden': stodden,
         'isbn_doi1': isbn_doi1,
@@ -295,8 +318,8 @@ def bibs(entries):
     beaulieu_arxiv     = bm.Bib(entries['beaulieu_arxiv'])
     beaulieu_arxiv_dup = bm.Bib(entries['beaulieu_arxiv_dup'])
     hunter             = bm.Bib(entries['hunter'])
-    oliphant_dup       = bm.Bib(entries['oliphant_dup'])
-    no_oliphant        = bm.Bib(entries['no_oliphant'])
+    slipher_dup        = bm.Bib(entries['slipher_dup'])
+    slipher_guy        = bm.Bib(entries['slipher_guy'])
     sing               = bm.Bib(entries['sing'])
     stodden            = bm.Bib(entries['stodden'])
 
@@ -305,8 +328,8 @@ def bibs(entries):
         'beaulieu_arxiv':     beaulieu_arxiv,
         'beaulieu_arxiv_dup': beaulieu_arxiv_dup,
         'hunter':             hunter,
-        'oliphant_dup':       oliphant_dup,
-        'no_oliphant':        no_oliphant,
+        'slipher_dup':        slipher_dup,
+        'slipher_guy':        slipher_guy,
         'sing':               sing,
         'stodden':            stodden,
         }

--- a/tests/test_bib_manager.py
+++ b/tests/test_bib_manager.py
@@ -420,7 +420,7 @@ def test_display_list_verb_neg(capfd, mock_init, mock_init_sample):
 
 def test_display_list_verb_zero(capfd, mock_init, mock_init_sample):
     bibs = bm.load()
-    bibs = [bibs[14], bibs[16]]
+    bibs = [bibs[11], bibs[13]]
     bm.display_list(bibs, verb=0)
     captured = capfd.readouterr()
     # Trick to see how the screen output looks:
@@ -465,7 +465,7 @@ def test_display_list_no_title(capfd, mock_init, mock_init_sample):
 
 def test_display_list_verb_one(capfd, mock_init, mock_init_sample):
     bibs = bm.load()
-    bibs = [bibs[14], bibs[16]]
+    bibs = [bibs[11], bibs[13]]
     bm.display_list(bibs, verb=1)
     captured = capfd.readouterr()
     expected_output = '\x1b[0m\x1b[?7h\x1b[0m\r\n\x1b[0;38;5;33mTitle\x1b[0m: \x1b[0;38;5;130mStudies based on the colors and magnitudes in stellar clusters. VII.\r\n    The distances, distribution in space, and dimensions of 69 globular\r\n    clusters., 1918\x1b[0m\r\n\x1b[0;38;5;33mAuthors\x1b[0m: \x1b[0;38;5;130m{Shapley}, H.\x1b[0m\r\n\x1b[0;38;5;33mADS URL\x1b[0m: \x1b[0;38;5;130mhttp://adsabs.harvard.edu/abs/1918ApJ....48..154S\x1b[0m\r\n\x1b[0;38;5;33mbibcode\x1b[0m: \x1b[0;38;5;130m1918ApJ....48..154S\x1b[0m\r\n\x1b[0;38;5;33mkey\x1b[0m: \x1b[0;38;5;142mShapley1918apjDistanceGlobularClusters\x1b[0m\r\n\x1b[0m\x1b[0m\x1b[?7h\x1b[0m\r\n\x1b[0;38;5;33mTitle\x1b[0m: \x1b[0;38;5;130mThe radial velocity of the Andromeda Nebula, 1913\x1b[0m\r\n\x1b[0;38;5;33mAuthors\x1b[0m: \x1b[0;38;5;130m{Slipher}, V. M.\x1b[0m\r\n\x1b[0;38;5;33mADS URL\x1b[0m: \x1b[0;38;5;130mhttps://ui.adsabs.harvard.edu/abs/1913LowOB...2...56S\x1b[0m\r\n\x1b[0;38;5;33mbibcode\x1b[0m: \x1b[0;38;5;130m1913LowOB...2...56S\x1b[0m\r\n\x1b[0;38;5;33mPDF file\x1b[0m: \x1b[0;38;5;248;3mSlipher1913.pdf\x1b[0m\r\n\x1b[0;38;5;33mkey\x1b[0m: \x1b[0;38;5;142mSlipher1913lobAndromedaRarialVelocity\x1b[0m\r\n\x1b[0m'
@@ -508,7 +508,7 @@ def test_display_list_no_ads(capfd, mock_init, mock_init_sample):
 
 def test_display_list_verb_full(capfd, mock_init, mock_init_sample):
     bibs = bm.load()
-    bibs = [bibs[14], bibs[16]]
+    bibs = [bibs[11], bibs[13]]
     bm.display_list(bibs, verb=3)
     captured = capfd.readouterr()
     assert captured.out == '\x1b[0m\x1b[?7h\x1b[0;38;5;248;3m\r\n::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::\r\n\x1b[0m\x1b[0;38;5;248;3m\x1b[0;38;5;34;1;4m@ARTICLE\x1b[0m{\x1b[0;38;5;142mShapley1918apjDistanceGlobularClusters\x1b[0m,\r\n   \x1b[0;38;5;33mauthor\x1b[0m = \x1b[0;38;5;130m{{Shapley}, H.}\x1b[0m,\r\n    \x1b[0;38;5;33mtitle\x1b[0m = \x1b[0;38;5;130m"{Studies based on the colors and magnitudes in stellar clusters. VII. The distances, distribution in space, and dimensions of 69 globular clusters.}"\x1b[0m,\r\n  \x1b[0;38;5;33mjournal\x1b[0m = \x1b[0;38;5;130m{\\apj}\x1b[0m,\r\n     \x1b[0;38;5;33myear\x1b[0m = \x1b[0;38;5;30m1918\x1b[0m,\r\n    \x1b[0;38;5;33mmonth\x1b[0m = \x1b[0;38;5;124moct\x1b[0m,\r\n   \x1b[0;38;5;33mvolume\x1b[0m = \x1b[0;38;5;30m48\x1b[0m,\r\n      \x1b[0;38;5;33mdoi\x1b[0m = \x1b[0;38;5;130m{10.1086/142423}\x1b[0m,\r\n   \x1b[0;38;5;33madsurl\x1b[0m = \x1b[0;38;5;130m{http://adsabs.harvard.edu/abs/1918ApJ....48..154S}\x1b[0m,\r\n  \x1b[0;38;5;33madsnote\x1b[0m = \x1b[0;38;5;130m{Provided by the SAO/NASA Astrophysics Data System}\x1b[0m\r\n}\r\n\r\n\x1b[0;38;5;248;3mpdf: Slipher1913.pdf\r\n\x1b[0;38;5;34;1;4m@ARTICLE\x1b[0m{\x1b[0;38;5;142mSlipher1913lobAndromedaRarialVelocity\x1b[0m,\r\n       \x1b[0;38;5;33mauthor\x1b[0m = \x1b[0;38;5;130m{{Slipher}, V.~M.}\x1b[0m,\r\n        \x1b[0;38;5;33mtitle\x1b[0m = \x1b[0;38;5;130m"{The radial velocity of the Andromeda Nebula}"\x1b[0m,\r\n      \x1b[0;38;5;33mjournal\x1b[0m = \x1b[0;38;5;130m{Lowell Observatory Bulletin}\x1b[0m,\r\n     \x1b[0;38;5;33mkeywords\x1b[0m = \x1b[0;38;5;130m{GALAXIES: MOTION IN LINE OF SIGHT, ANDROMEDA GALAXY}\x1b[0m,\r\n         \x1b[0;38;5;33myear\x1b[0m = \x1b[0;38;5;30m1913\x1b[0m,\r\n        \x1b[0;38;5;33mmonth\x1b[0m = \x1b[0;38;5;124mJan\x1b[0m,\r\n       \x1b[0;38;5;33mvolume\x1b[0m = \x1b[0;38;5;130m{1}\x1b[0m,\r\n        \x1b[0;38;5;33mpages\x1b[0m = \x1b[0;38;5;130m{56-57}\x1b[0m,\r\n       \x1b[0;38;5;33madsurl\x1b[0m = \x1b[0;38;5;130m{https://ui.adsabs.harvard.edu/abs/1913LowOB...2...56S}\x1b[0m,\r\n      \x1b[0;38;5;33madsnote\x1b[0m = \x1b[0;38;5;130m{Provided by the SAO/NASA Astrophysics Data System}\x1b[0m\r\n}\r\n\r\n\x1b[0m'
@@ -891,34 +891,34 @@ def test_merge_bibs_no_titles(capfd, mock_init):
 
 @pytest.mark.parametrize('mock_input', [['n']], indirect=True)
 def test_merge_duplicate_key_ingnore(bibs, mock_init_sample, mock_input):
-    bm.merge(new=[bibs['oliphant_dup']])
+    bm.merge(new=[bibs['slipher_dup']])
     loaded_bibs = bm.load()
     assert len(loaded_bibs) == nentries
-    assert bibs['oliphant_dup'] in loaded_bibs
+    assert bibs['slipher_dup'] in loaded_bibs
 
 
-@pytest.mark.parametrize('mock_input', [['Oliphant2016numpyb']], indirect=True)
+@pytest.mark.parametrize('mock_input', [['Slipher1913lobAnd']], indirect=True)
 def test_merge_duplicate_key_rename(bibs, mock_init_sample, mock_input):
-    bm.merge(new=[bibs['oliphant_dup']])
+    bm.merge(new=[bibs['slipher_dup']])
     loaded_bibs = bm.load()
     assert len(loaded_bibs) == nentries + 1
-    assert 'Oliphant2016numpyb' in [e.key for e in loaded_bibs]
+    assert 'Slipher1913lobAnd' in [e.key for e in loaded_bibs]
 
 
 @pytest.mark.parametrize('mock_input', [['']], indirect=True)
 def test_merge_duplicate_title_ignore(bibs, mock_init_sample, mock_input):
-    bm.merge(new=[bibs['no_oliphant']])
+    bm.merge(new=[bibs['slipher_guy']])
     loaded_bibs = bm.load()
     assert len(loaded_bibs) == nentries
-    assert bibs['no_oliphant'] not in loaded_bibs
+    assert bibs['slipher_guy'] not in loaded_bibs
 
 
 @pytest.mark.parametrize('mock_input', [['a']], indirect=True)
 def test_merge_duplicate_title_add(bibs, mock_init_sample, mock_input):
-    bm.merge(new=[bibs['no_oliphant']])
+    bm.merge(new=[bibs['slipher_guy']])
     loaded_bibs = bm.load()
     assert len(loaded_bibs) == nentries + 1
-    assert bibs['no_oliphant'] in loaded_bibs
+    assert bibs['slipher_guy'] in loaded_bibs
 
 
 def test_duplicate_isbn_different_doi(capfd, entries):
@@ -993,23 +993,23 @@ def test_search_author_lastname(mock_init_sample):
     matches = bm.search(authors="oliphant")
     assert len(matches) == 2
     keys = [m.key for m in matches]
-    assert 'JonesEtal2001scipy' in keys
-    assert 'Oliphant2006numpy'  in keys
+    assert 'HarrisEtal2020natNumpy' in keys
+    assert 'VirtanenEtal2020natmeScipy' in keys
 
 
 def test_search_author_last_initials(mock_init_sample):
     matches = bm.search(authors="oliphant, t")
     assert len(matches) == 2
     keys = [m.key for m in matches]
-    assert 'JonesEtal2001scipy' in keys
-    assert 'Oliphant2006numpy'  in keys
+    assert 'HarrisEtal2020natNumpy' in keys
+    assert 'VirtanenEtal2020natmeScipy' in keys
 
 
 def test_search_author_first(mock_init_sample):
-    matches = bm.search(authors="^oliphant, t")
+    matches = bm.search(authors="^virtanen, p")
     assert len(matches) == 1
     keys = [m.key for m in matches]
-    assert 'Oliphant2006numpy'  in keys
+    assert 'VirtanenEtal2020natmeScipy' in keys
 
 
 def test_search_author_multiple(mock_init_sample):
@@ -1017,15 +1017,15 @@ def test_search_author_multiple(mock_init_sample):
     matches = bm.search(authors=["oliphant, t", "jones, e"])
     assert len(matches) == 1
     keys = [m.key for m in matches]
-    assert 'JonesEtal2001scipy' in keys
+    assert 'VirtanenEtal2020natmeScipy' in keys
 
 
 def test_search_author_year_title(mock_init_sample):
     # Combined-fields querries act with AND logic:
-    matches = bm.search(authors="oliphant, t", year=2006, title="numpy")
+    matches = bm.search(authors="oliphant, t", year=2020, title="numpy")
     assert len(matches) == 1
     keys = [m.key for m in matches]
-    assert 'Oliphant2006numpy'  in keys
+    assert 'HarrisEtal2020natNumpy'  in keys
 
 
 def test_search_title_multiple(mock_init_sample):
@@ -1047,18 +1047,18 @@ def test_search_title_entry_without_title(mock_init_sample, entries):
 
 
 def test_search_year_specific(mock_init_sample):
-    matches = bm.search(authors="cubillos, p", year=2016)
+    matches = bm.search(authors="granger", year=2007)
     assert len(matches) == 1
     keys = [m.key for m in matches]
-    assert 'Cubillos2016phdThesis' in keys
+    assert 'PerezGranger2007cseIPython' in keys
 
 
 def test_search_year_range(mock_init_sample):
-    matches = bm.search(authors="cubillos, p", year=[2013,2016])
+    matches = bm.search(authors="granger, b", year=[2007,2018])
     assert len(matches) == 2
     keys = [m.key for m in matches]
-    assert 'CubillosEtal2013apjWASP8b' in keys
-    assert 'Cubillos2016phdThesis' in keys
+    assert 'PerezGranger2007cseIPython' in keys
+    assert 'MeurerEtal2017pjcsSYMPY' in keys
 
 
 def test_search_bibcode(mock_init_sample):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -36,7 +36,9 @@ Use one line for each BibTeX entry, separate fields with blank spaces.
 
 """
 
-expected_numpy = "(Press 'tab' for autocomplete)\n\n\x1b[0m\x1b[?7h\x1b[0m\r\n\x1b[0;38;5;33mTitle\x1b[0m: \x1b[0;38;5;130mNumpy: A guide to NumPy, 2006\x1b[0m\r\n\x1b[0;38;5;33mAuthors\x1b[0m: \x1b[0;38;5;130mOliphant, Travis\x1b[0m\r\n\x1b[0;38;5;33mkey\x1b[0m: \x1b[0;38;5;142mOliphant2006numpy\x1b[0m\r\n\x1b[0m"
+expected_sympy = "(Press 'tab' for autocomplete)\n\n\x1b[0m\x1b[?7h\x1b[0m\r\n\x1b[0;38;5;33mTitle\x1b[0m: \x1b[0;38;5;130mSymPy: symbolic computing in Python, 2017\x1b[0m\r\n\x1b[0;38;5;33mAuthors\x1b[0m: \x1b[0;38;5;130mMeurer, Aaron; et al.\x1b[0m\r\n\x1b[0;38;5;33mkey\x1b[0m: \x1b[0;38;5;142mMeurerEtal2017pjcsSYMPY\x1b[0m\r\n\x1b[0m"
+
+expected_slipher = "(Press 'tab' for autocomplete)\n\n\x1b[0m\x1b[?7h\x1b[0m\r\n\x1b[0;38;5;33mTitle\x1b[0m: \x1b[0;38;5;130mThe radial velocity of the Andromeda Nebula, 1913\x1b[0m\r\n\x1b[0;38;5;33mAuthors\x1b[0m: \x1b[0;38;5;130m{Slipher}, V. M.\x1b[0m\r\n\x1b[0;38;5;33mkey\x1b[0m: \x1b[0;38;5;142mSlipher1913lobAndromedaRarialVelocity\x1b[0m\r\n\x1b[0m"
 
 
 def test_cli_version(capsys):
@@ -109,7 +111,7 @@ def test_cli_reset_config(capsys, mock_init_sample):
 
 
 def test_cli_reset_keep_database(capsys, mock_init_sample):
-    bibfile = u.HOME+"examples/sample.bib"
+    bibfile = u.HOME + "examples/sample.bib"
     # Simulate user input:
     sys.argv = f"bibm reset {bibfile}".split()
     cli.main()
@@ -169,16 +171,24 @@ def test_cli_search_null(capsys, mock_init_sample, mock_prompt_session):
 
 
 @pytest.mark.parametrize('mock_prompt_session',
-    [['year:1984'],
-     ['year: 1984'],
-     ['year:1984-1985'],
-     ['year:-1884'],
-     ['year:2020-']], indirect=True)
+    [['year:1913'],
+     ['year: 1913'],
+     ['year:1910-1913'],
+     ['year:-1913']], indirect=True)
 def test_cli_search_year(capsys, mock_init_sample, mock_prompt_session):
     sys.argv = "bibm search".split()
     cli.main()
     captured = capsys.readouterr()
-    assert captured.out == "(Press 'tab' for autocomplete)\n\n"
+    assert captured.out == expected_slipher
+
+
+@pytest.mark.parametrize('mock_prompt_session', [['year:2020-']], indirect=True)
+def test_cli_search_year_open_e(capsys, mock_init_sample, mock_prompt_session):
+    sys.argv = "bibm search".split()
+    cli.main()
+    captured = capsys.readouterr()
+    expected_output = "(Press 'tab' for autocomplete)\n\n\x1b[0m\x1b[?7h\x1b[0m\r\n\x1b[0;38;5;33mTitle\x1b[0m: \x1b[0;38;5;130mArray programming with NumPy, 2020\x1b[0m\r\n\x1b[0;38;5;33mAuthors\x1b[0m: \x1b[0;38;5;130m{Harris}, Charles R.; et al.\x1b[0m\r\n\x1b[0;38;5;33mkey\x1b[0m: \x1b[0;38;5;142mHarrisEtal2020natNumpy\x1b[0m\r\n\x1b[0m\x1b[0m\x1b[?7h\x1b[0m\r\n\x1b[0;38;5;33mTitle\x1b[0m: \x1b[0;38;5;130mSciPy 1.0: fundamental algorithms for scientific computing in Python,\r\n    2020\x1b[0m\r\n\x1b[0;38;5;33mAuthors\x1b[0m: \x1b[0;38;5;130m{Virtanen}, Pauli; et al.\x1b[0m\r\n\x1b[0;38;5;33mkey\x1b[0m: \x1b[0;38;5;142mVirtanenEtal2020natmeScipy\x1b[0m\r\n\x1b[0m"
+    assert captured.out == expected_output
 
 
 @pytest.mark.parametrize('mock_prompt_session',
@@ -187,71 +197,69 @@ def test_cli_search_year_invalid(capsys, mock_init_sample, mock_prompt_session):
     sys.argv = "bibm search".split()
     cli.main()
     captured = capsys.readouterr()
-    assert captured.out == (
-        "(Press 'tab' for autocomplete)\n\n"
-        "\nInvalid format for input year: 1984a\n")
+    assert captured.out == "(Press 'tab' for autocomplete)\n\n"
+
 
 @pytest.mark.parametrize('mock_prompt_session',
-    [['author:"oliphant"'],
-     ['author:"oliphant, t"']], indirect=True)
+    [['author:"virtanen"'],
+     ['author:"Virtanen"'],
+     ['author:"virtanen, p"']], indirect=True)
 def test_cli_search_author(capsys, mock_init_sample, mock_prompt_session):
     sys.argv = "bibm search".split()
     cli.main()
     captured = capsys.readouterr()
-    expected_output = "(Press 'tab' for autocomplete)\n\n\x1b[0m\x1b[?7h\x1b[0m\r\n\x1b[0;38;5;33mTitle\x1b[0m: \x1b[0;38;5;130mSciPy: Open source scientific tools for Python, 2001\x1b[0m\r\n\x1b[0;38;5;33mAuthors\x1b[0m: \x1b[0;38;5;130mJones, Eric; et al.\x1b[0m\r\n\x1b[0;38;5;33mkey\x1b[0m: \x1b[0;38;5;142mJonesEtal2001scipy\x1b[0m\r\n\x1b[0m\x1b[0m\x1b[?7h\x1b[0m\r\n\x1b[0;38;5;33mTitle\x1b[0m: \x1b[0;38;5;130mNumpy: A guide to NumPy, 2006\x1b[0m\r\n\x1b[0;38;5;33mAuthors\x1b[0m: \x1b[0;38;5;130mOliphant, Travis\x1b[0m\r\n\x1b[0;38;5;33mkey\x1b[0m: \x1b[0;38;5;142mOliphant2006numpy\x1b[0m\r\n\x1b[0m"
+    expected_output = "(Press 'tab' for autocomplete)\n\n\x1b[0m\x1b[?7h\x1b[0m\r\n\x1b[0;38;5;33mTitle\x1b[0m: \x1b[0;38;5;130mArray programming with NumPy, 2020\x1b[0m\r\n\x1b[0;38;5;33mAuthors\x1b[0m: \x1b[0;38;5;130m{Harris}, Charles R.; et al.\x1b[0m\r\n\x1b[0;38;5;33mkey\x1b[0m: \x1b[0;38;5;142mHarrisEtal2020natNumpy\x1b[0m\r\n\x1b[0m\x1b[0m\x1b[?7h\x1b[0m\r\n\x1b[0;38;5;33mTitle\x1b[0m: \x1b[0;38;5;130mSciPy 1.0: fundamental algorithms for scientific computing in Python,\r\n    2020\x1b[0m\r\n\x1b[0;38;5;33mAuthors\x1b[0m: \x1b[0;38;5;130m{Virtanen}, Pauli; et al.\x1b[0m\r\n\x1b[0;38;5;33mkey\x1b[0m: \x1b[0;38;5;142mVirtanenEtal2020natmeScipy\x1b[0m\r\n\x1b[0m"
     assert captured.out == expected_output
 
 
 @pytest.mark.parametrize('mock_prompt_session',
-    [['author:"^oliphant"'],
-     ['author:"^oliphant, t"']], indirect=True)
+    [['author:"^virtanen"'],
+     ['author:"^virtanen, p"']], indirect=True)
 def test_cli_search_first_author(capsys, mock_init_sample, mock_prompt_session):
     sys.argv = "bibm search".split()
     cli.main()
     captured = capsys.readouterr()
-    expected_output = expected_numpy
+    expected_output = "(Press 'tab' for autocomplete)\n\n\x1b[0m\x1b[?7h\x1b[0m\r\n\x1b[0;38;5;33mTitle\x1b[0m: \x1b[0;38;5;130mSciPy 1.0: fundamental algorithms for scientific computing in Python,\r\n    2020\x1b[0m\r\n\x1b[0;38;5;33mAuthors\x1b[0m: \x1b[0;38;5;130m{Virtanen}, Pauli; et al.\x1b[0m\r\n\x1b[0;38;5;33mkey\x1b[0m: \x1b[0;38;5;142mVirtanenEtal2020natmeScipy\x1b[0m\r\n\x1b[0m"
     assert captured.out == expected_output
 
 
 @pytest.mark.parametrize('mock_prompt_session',
-    [['author:"oliphant" author:"jones, e"']], indirect=True)
+    [['author:"granger" author:"meurer, a"']], indirect=True)
 def test_cli_search_multiple_authors(
         capsys, mock_init_sample, mock_prompt_session):
     sys.argv = "bibm search".split()
     cli.main()
     captured = capsys.readouterr()
-    expected_output = "(Press 'tab' for autocomplete)\n\n\x1b[0m\x1b[?7h\x1b[0m\r\n\x1b[0;38;5;33mTitle\x1b[0m: \x1b[0;38;5;130mSciPy: Open source scientific tools for Python, 2001\x1b[0m\r\n\x1b[0;38;5;33mAuthors\x1b[0m: \x1b[0;38;5;130mJones, Eric; et al.\x1b[0m\r\n\x1b[0;38;5;33mkey\x1b[0m: \x1b[0;38;5;142mJonesEtal2001scipy\x1b[0m\r\n\x1b[0m"
-    assert captured.out == expected_output
+    assert captured.out == expected_sympy
 
 
 @pytest.mark.parametrize('mock_prompt_session',
-    [['author:"oliphant, t" year:2006']], indirect=True)
+    [['author:"granger" year:2017']], indirect=True)
 def test_cli_search_author_year(capsys, mock_init_sample, mock_prompt_session):
     sys.argv = "bibm search".split()
     cli.main()
     captured = capsys.readouterr()
-    assert captured.out == expected_numpy
+    assert captured.out == expected_sympy
 
 
 @pytest.mark.parametrize('mock_prompt_session',
-    [['author:"oliphant, t" year:2006 year:2001']], indirect=True)
+    [['author:"slipher" year:1913 year:2001']], indirect=True)
 def test_cli_search_author_year_ignore_second_year(capsys, mock_init_sample,
         mock_prompt_session):
     sys.argv = "bibm search".split()
     cli.main()
     captured = capsys.readouterr()
-    assert captured.out == expected_numpy
+    assert captured.out == expected_slipher
 
 
 @pytest.mark.parametrize('mock_prompt_session',
-    [['title:"HD 209458b" title:"atmospheric circulation"']], indirect=True)
+    [['title:"Andromeda" title:"radial velocity"']], indirect=True)
 def test_cli_search_multiple_title_kws(capsys, mock_init_sample,
         mock_prompt_session):
     sys.argv = "bibm search".split()
     cli.main()
     captured = capsys.readouterr()
-    expected_output = "(Press 'tab' for autocomplete)\n\n\x1b[0m\x1b[?7h\x1b[0m\r\n\x1b[0;38;5;33mTitle\x1b[0m: \x1b[0;38;5;130mAtmospheric Circulation of Hot Jupiters: Coupled Radiative-Dynamical\r\n    General Circulation Model Simulations of HD 189733b and HD 209458b, 2009\x1b[0m\r\n\x1b[0;38;5;33mAuthors\x1b[0m: \x1b[0;38;5;130m{Showman}, Adam P.; et al.\x1b[0m\r\n\x1b[0;38;5;33mkey\x1b[0m: \x1b[0;38;5;142mShowmanEtal2009apjRadGCM\x1b[0m\r\n\x1b[0m"
-    assert captured.out == expected_output
+    assert captured.out == expected_slipher
 
 
 @pytest.mark.parametrize('mock_prompt_session',
@@ -277,13 +285,15 @@ def test_cli_search_multiple_bibcodes(capsys, mock_init_sample,
     assert captured.out == expected_output
 
 
-@pytest.mark.parametrize('mock_prompt_session',
-    [['key:Oliphant2006numpy']], indirect=True)
+@pytest.mark.parametrize(
+    'mock_prompt_session',
+    [['key:Slipher1913lobAndromedaRarialVelocity']],
+    indirect=True)
 def test_cli_search_key(capsys, mock_init_sample, mock_prompt_session):
     sys.argv = "bibm search".split()
     cli.main()
     captured = capsys.readouterr()
-    assert captured.out == expected_numpy
+    assert captured.out == expected_slipher
 
 
 @pytest.mark.parametrize('mock_prompt_session',
@@ -1231,7 +1241,7 @@ def test_cli_pdf_set_prompt_missing_pdf(capsys, mock_init_sample,
 
 
 @pytest.mark.parametrize('mock_prompt_session',
-    [['author:"^oliphant, t"']], indirect=True)
+    [['author:"^slipher"']], indirect=True)
 def test_cli_older_pickle(capsys, mock_init_sample, mock_prompt_session):
     # Mock pickle DB file with older version than bibmanager:
     with open(u.BM_DATABASE(), 'wb') as handle:
@@ -1244,7 +1254,7 @@ def test_cli_older_pickle(capsys, mock_init_sample, mock_prompt_session):
     assert captured.out == (
         "Updating database file from version 0.0.0 to version "
         f"{bibmanager.__version__}.\n"
-        + expected_numpy)
+        + expected_slipher)
 
 
 def test_cli_future_pickle(capsys, mock_init_sample):

--- a/tests/test_latex_manager.py
+++ b/tests/test_latex_manager.py
@@ -6,6 +6,7 @@ import pytest
 import pathlib
 
 import numpy as np
+from conftest import cd
 
 import bibmanager.utils as u
 import bibmanager.bib_manager   as bm
@@ -149,24 +150,23 @@ def test_parse_subtex_files(tmp_path):
 
 def test_build_bib_inplace(mock_init):
     bm.merge(u.HOME+"examples/sample.bib")
-    here = os.getcwd()
-    os.chdir(u.HOME+"examples")
-    missing = lm.build_bib("sample.tex")
-    files = os.listdir(".")
-    assert "texsample.bib" in files
-    # Now check content:
-    np.testing.assert_array_equal(missing, np.zeros(0,dtype="U"))
-    bibs = bm.read_file("texsample.bib")
-    assert len(bibs) == 7
-    keys = [bib.key for bib in bibs]
-    assert "AASteamHendrickson2018aastex62" in keys
-    assert "vanderWaltEtal2011numpy"    in keys
-    assert "JonesEtal2001scipy"         in keys
-    assert "Hunter2007ieeeMatplotlib"   in keys
-    assert "PerezGranger2007cseIPython" in keys
-    assert "MeurerEtal2017pjcsSYMPY"    in keys
-    assert "Astropycollab2013aaAstropy" in keys
-    os.chdir(here)
+    with cd(u.HOME+'examples'):
+        missing = lm.build_bib("sample.tex")
+        files = os.listdir(".")
+        assert "texsample.bib" in files
+        # Now check content:
+        np.testing.assert_array_equal(missing, np.zeros(0,dtype="U"))
+        bibs = bm.read_file("texsample.bib")
+        assert len(bibs) == 8
+        keys = [bib.key for bib in bibs]
+        assert "AASteamHendrickson2018aastex62" in keys
+        assert "HarrisEtal2020natNumpy" in keys
+        assert "VirtanenEtal2020natmeScipy" in keys
+        assert "Hunter2007ieeeMatplotlib" in keys
+        assert "PerezGranger2007cseIPython" in keys
+        assert "MeurerEtal2017pjcsSYMPY" in keys
+        assert "Astropycollab2013aaAstropy" in keys
+        assert "Cubillos2019zndoBibmanager" in keys
 
 
 def test_build_bib_remote(mock_init):

--- a/tests/test_latex_manager.py
+++ b/tests/test_latex_manager.py
@@ -66,6 +66,7 @@ def test_citations3():
     assert next(cites) == "Author2"
     assert next(cites) == "Author3"
 
+
 def test_citations4():
     # Match all of these:
     assert next(lm.citations("\\cite{AuthorA}"))          == "AuthorA"
@@ -96,6 +97,7 @@ def test_citations4():
     assert next(lm.citations("\\citeyearpar{AuthorZ}"))   == "AuthorZ"
     assert next(lm.citations("\\citeyearpar*{AuthorAA}")) == "AuthorAA"
 
+
 def test_citations5():
     # The sample tex file:
     texfile = os.path.expanduser('~') + "/.bibmanager/examples/sample.tex"
@@ -105,13 +107,16 @@ def test_citations5():
     cites = [citation for citation in lm.citations(tex)]
     assert cites == [
         'AASteamHendrickson2018aastex62',
-        'vanderWaltEtal2011numpy',
-        'JonesEtal2001scipy',
+        'HarrisEtal2020natNumpy',
+        'VirtanenEtal2020natmeScipy',
         'Hunter2007ieeeMatplotlib',
         'PerezGranger2007cseIPython',
         'MeurerEtal2017pjcsSYMPY',
         'Astropycollab2013aaAstropy',
-        'AASteamHendrickson2018aastex62']
+        'AASteamHendrickson2018aastex62',
+        'Cubillos2019zndoBibmanager',
+    ]
+
 
 def test_parse_subtex_files(tmp_path):
     os.chdir(tmp_path)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -543,3 +543,101 @@ def test_tokenizer_value_blank():
     tokens = u.tokenizer('Title', '')
     assert tokens == []
 
+
+def test_parse_search_null(mock_init_sample):
+    matches = u.parse_search('')
+    assert matches == []
+
+
+@pytest.mark.parametrize('search_text', (
+    'year:1913',
+    'year: 1913',
+    'year:1912-1913',
+    'year:-1913'))
+def test_parse_search_year_fixed(mock_init_sample, search_text):
+    matches = u.parse_search(search_text)
+    assert len(matches) == 1
+    assert matches[0].key == 'Slipher1913lobAndromedaRarialVelocity'
+
+
+def test_parse_search_year_open(mock_init_sample):
+    matches = u.parse_search('year:2020-')
+    print(matches[1].key)
+    assert len(matches) == 2
+    assert matches[0].key == 'HarrisEtal2020natNumpy'
+    assert matches[1].key == 'VirtanenEtal2020natmeScipy'
+
+
+def test_parse_search_year_invalid(mock_init_sample):
+    matches = u.parse_search('year:1913a')
+    assert matches == []
+
+
+@pytest.mark.parametrize('search_text', (
+    'author:"Oliphant"',
+    'author:"Oliphant, T."',
+    'author:"oliphant"',
+    'author:"oliphant, t"',))
+def test_parse_search_author(mock_init_sample, search_text):
+    matches = u.parse_search(search_text)
+    assert len(matches) == 2
+    assert matches[0].key == 'HarrisEtal2020natNumpy'
+    assert matches[1].key == 'VirtanenEtal2020natmeScipy'
+
+
+def test_parse_search_first_author(mock_init_sample):
+    matches = u.parse_search('author:"^Virtanen"')
+    assert len(matches) == 1
+    assert matches[0].key == 'VirtanenEtal2020natmeScipy'
+
+
+def test_parse_search_multiple_authors(mock_init_sample):
+    matches = u.parse_search('author:"oliphant" author:"jones, e"')
+    assert len(matches) == 1
+    assert matches[0].key == 'VirtanenEtal2020natmeScipy'
+
+
+def test_parse_search_author_year(mock_init_sample):
+    matches = u.parse_search('author:"^virtanen" year:2020')
+    assert len(matches) == 1
+    assert matches[0].key == 'VirtanenEtal2020natmeScipy'
+
+
+def test_parse_search_author_year_ignore_second_year(mock_init_sample):
+    matches = u.parse_search('author:"^virtanen" year:2020 year:2001')
+    assert len(matches) == 1
+    assert matches[0].key == 'VirtanenEtal2020natmeScipy'
+
+
+def test_parse_search_multiple_title_kws(mock_init_sample):
+    matches = u.parse_search(
+        'title:"HD 209458b" title:"atmospheric circulation"')
+
+
+def test_parse_search_bibcode(mock_init_sample):
+    matches = u.parse_search('bibcode:2013A&A...558A..33A')
+    matches = u.parse_search('bibcode:2013A%26A...558A..33A')
+
+
+def test_parse_search_multiple_bibcodes(mock_init_sample):
+    matches = u.parse_search(
+        'bibcode:1917PASP...29..206C bibcode:1918ApJ....48..154S')
+    assert len(matches) == 2
+    assert matches[0].key == 'Curtis1917paspIslandUniverseTheory'
+    assert matches[1].key == 'Shapley1918apjDistanceGlobularClusters'
+
+
+def test_parse_search_key(mock_init_sample):
+    matches = u.parse_search('key: VirtanenEtal2020natmeScipy')
+    assert len(matches) == 1
+    assert matches[0].key == 'VirtanenEtal2020natmeScipy'
+
+
+def test_parse_search_multiple_keys(mock_init_sample):
+    matches = u.parse_search(
+        'key:Curtis1917paspIslandUniverseTheory '
+        'key:Shapley1918apjDistanceGlobularClusters')
+    assert len(matches) == 2
+    assert matches[0].key == 'Curtis1917paspIslandUniverseTheory'
+    assert matches[1].key == 'Shapley1918apjDistanceGlobularClusters'
+


### PR DESCRIPTION
Since we were here last time. Why not letting the tag-search bar in the browser allow any type of search?
Now this bar lets the user search by authors, years, tags, etc (just as in the ``bibm search`` command.)

The keyword shortcut to trigger the search changed from ``t`` to ``k`` (as in 'keyword'), there was no other better shortcut available...